### PR TITLE
Extended ProxyAuthenticator interface

### DIFF
--- a/src/main/java/org/littleshoot/proxy/ProxyAuthenticator.java
+++ b/src/main/java/org/littleshoot/proxy/ProxyAuthenticator.java
@@ -1,5 +1,7 @@
 package org.littleshoot.proxy;
 
+import io.netty.handler.codec.http.HttpRequest;
+
 /**
  * Interface for objects that can authenticate someone for using our Proxy on
  * the basis of a username and password.
@@ -7,7 +9,7 @@ package org.littleshoot.proxy;
 public interface ProxyAuthenticator {
     /**
      * Authenticates the user using the specified userName and password.
-     * 
+     *
      * @param userName
      *            The user name.
      * @param password
@@ -15,13 +17,13 @@ public interface ProxyAuthenticator {
      * @return <code>true</code> if the credentials are acceptable, otherwise
      *         <code>false</code>.
      */
-    boolean authenticate(String userName, String password);
-    
+    boolean authenticate(String userName, String password, HttpRequest httpRequest);
+
     /**
-     * The realm value to be used in the request for proxy authentication 
+     * The realm value to be used in the request for proxy authentication
      * ("Proxy-Authenticate" header). Returning null will cause the string
      * "Restricted Files" to be used by default.
-     * 
+     *
      * @return
      */
     String getRealm();

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -990,7 +990,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         
         String userName = StringUtils.substringBefore(decodedString, ":");
         String password = StringUtils.substringAfter(decodedString, ":");
-        if (!authenticator.authenticate(userName, password)) {
+        if (!authenticator.authenticate(userName, password, request)) {
             writeAuthenticationRequired(authenticator.getRealm());
             return true;
         }

--- a/src/test/java/org/littleshoot/proxy/UsernamePasswordAuthenticatingProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/UsernamePasswordAuthenticatingProxyTest.java
@@ -1,5 +1,7 @@
 package org.littleshoot.proxy;
 
+import io.netty.handler.codec.http.HttpRequest;
+
 /**
  * Tests a single proxy that requires username/password authentication.
  */
@@ -24,7 +26,7 @@ public class UsernamePasswordAuthenticatingProxyTest extends BaseProxyTest
     }
 
     @Override
-    public boolean authenticate(String userName, String password) {
+    public boolean authenticate(String userName, String password, HttpRequest httpRequest) {
         return getUsername().equals(userName) && getPassword().equals(password);
     }
 


### PR DESCRIPTION
It would be great to pass `request` itself into `ProxyAuthenticator.authenticate()` method. In some cases user might want to do some additional authentication based on things like hostname or headers.