### PR TITLE
Customize handling of http 502

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.littleshoot</groupId>
     <artifactId>littleproxy</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.3-VGS-SNAPSHOT</version>
+    <version>1.1.3.1-VGS-SNAPSHOT</version>
     <name>LittleProxy</name>
     <description>
         LittleProxy is a high performance HTTP proxy written in Java and using the Netty networking framework.

--- a/src/main/java/org/littleshoot/proxy/BadGatewayFailureHttpResponseComposer.java
+++ b/src/main/java/org/littleshoot/proxy/BadGatewayFailureHttpResponseComposer.java
@@ -6,8 +6,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import org.littleshoot.proxy.impl.ProxyUtils;
 
-
-public final class BadGatewayFailureHttpResponseComposer implements ServerConnectionFailureHttpResponseComposer {
+public class BadGatewayFailureHttpResponseComposer implements FailureHttpResponseComposer {
 
   /**
    * Tells the client that something went wrong trying to proxy its request. If the Bad Gateway is a response to
@@ -20,7 +19,7 @@ public final class BadGatewayFailureHttpResponseComposer implements ServerConnec
    */
   @Override
   public FullHttpResponse compose(HttpRequest httpRequest, Throwable cause) {
-    String body = "Bad Gateway: " + httpRequest.getUri();
+    String body = provideCustomMessage(httpRequest, cause);
 
     FullHttpResponse response = ProxyUtils.createFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_GATEWAY, body);
 
@@ -31,7 +30,13 @@ public final class BadGatewayFailureHttpResponseComposer implements ServerConnec
     return response;
   }
 
-  public FullHttpResponse compose(HttpRequest httpRequest) {
-    return this.compose(httpRequest, null);
+  /**
+   * The method can be overridden to provide a custom message along with 502 code
+   * @param httpRequest initial request
+   * @param cause an exception thrown on a failure
+   * @return custom message
+   */
+  protected String provideCustomMessage(HttpRequest httpRequest, Throwable cause) {
+    return "Bad Gateway: " + httpRequest.getUri();
   }
 }

--- a/src/main/java/org/littleshoot/proxy/BadGatewayFailureHttpResponseComposer.java
+++ b/src/main/java/org/littleshoot/proxy/BadGatewayFailureHttpResponseComposer.java
@@ -1,0 +1,37 @@
+package org.littleshoot.proxy;
+
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import org.littleshoot.proxy.impl.ProxyUtils;
+
+
+public final class BadGatewayFailureHttpResponseComposer implements FailureHttpResponseComposer {
+
+  /**
+   * Tells the client that something went wrong trying to proxy its request. If the Bad Gateway is a response to
+   * an HTTP HEAD request, the response will contain no body, but the Content-Length header will be set to the
+   * value it would have been if this 502 Bad Gateway were in response to a GET.
+   *
+   * @param httpRequest the HttpRequest that is resulting in the Bad Gateway response
+   * @param cause raised exception
+   * @return true if the connection will be kept open, or false if it will be disconnected
+   */
+  @Override
+  public FullHttpResponse compose(HttpRequest httpRequest, Throwable cause) {
+    String body = "Bad Gateway: " + httpRequest.getUri();
+
+    FullHttpResponse response = ProxyUtils.createFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_GATEWAY, body);
+
+    if (ProxyUtils.isHEAD(httpRequest)) {
+      // don't allow any body content in response to a HEAD request
+      response.content().clear();
+    }
+    return response;
+  }
+
+  public FullHttpResponse compose(HttpRequest httpRequest) {
+    return this.compose(httpRequest, null);
+  }
+}

--- a/src/main/java/org/littleshoot/proxy/BadGatewayFailureHttpResponseComposer.java
+++ b/src/main/java/org/littleshoot/proxy/BadGatewayFailureHttpResponseComposer.java
@@ -7,7 +7,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import org.littleshoot.proxy.impl.ProxyUtils;
 
 
-public final class BadGatewayFailureHttpResponseComposer implements FailureHttpResponseComposer {
+public final class BadGatewayFailureHttpResponseComposer implements ServerConnectionFailureHttpResponseComposer {
 
   /**
    * Tells the client that something went wrong trying to proxy its request. If the Bad Gateway is a response to

--- a/src/main/java/org/littleshoot/proxy/FailureHttpResponseComposer.java
+++ b/src/main/java/org/littleshoot/proxy/FailureHttpResponseComposer.java
@@ -1,0 +1,18 @@
+package org.littleshoot.proxy;
+
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpRequest;
+
+/**
+ * Interface for objects that can provide a custom http response on a specific failure.
+ */
+public interface FailureHttpResponseComposer {
+
+  /**
+   * Creates an {@link FullHttpResponse} based on initial request and failure cause
+   * @param httpRequest initial request
+   * @param cause an exception thrown during a failure
+   * @return failure http response
+   */
+  FullHttpResponse compose(HttpRequest httpRequest, Throwable cause);
+}

--- a/src/main/java/org/littleshoot/proxy/FailureHttpResponseComposer.java
+++ b/src/main/java/org/littleshoot/proxy/FailureHttpResponseComposer.java
@@ -1,0 +1,9 @@
+package org.littleshoot.proxy;
+
+
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpRequest;
+
+public interface FailureHttpResponseComposer {
+  FullHttpResponse compose(HttpRequest httpRequest, Throwable cause);
+}

--- a/src/main/java/org/littleshoot/proxy/FailureHttpResponseComposer.java
+++ b/src/main/java/org/littleshoot/proxy/FailureHttpResponseComposer.java
@@ -12,7 +12,7 @@ public interface FailureHttpResponseComposer {
    * Creates an {@link FullHttpResponse} based on initial request and failure cause
    * @param httpRequest initial request
    * @param cause an exception thrown during a failure
-   * @return failure http response 
+   * @return failure http response
    */
   FullHttpResponse compose(HttpRequest httpRequest, Throwable cause);
 }

--- a/src/main/java/org/littleshoot/proxy/FailureHttpResponseComposer.java
+++ b/src/main/java/org/littleshoot/proxy/FailureHttpResponseComposer.java
@@ -12,7 +12,7 @@ public interface FailureHttpResponseComposer {
    * Creates an {@link FullHttpResponse} based on initial request and failure cause
    * @param httpRequest initial request
    * @param cause an exception thrown during a failure
-   * @return failure http response
+   * @return failure http response 
    */
   FullHttpResponse compose(HttpRequest httpRequest, Throwable cause);
 }

--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -198,6 +198,14 @@ public interface HttpProxyServerBootstrap {
             HttpFiltersSource filtersSource);
 
     /**
+     *
+     * @param unrecoverableFailureHttpResponseComposer
+     * @return
+     */
+    HttpProxyServerBootstrap withUnrecoverableFailureHttpResponseComposer(
+        FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer);
+
+    /**
      * <p>
      * Specify whether or not to use secure DNS lookups for outbound
      * connections.

--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -203,7 +203,7 @@ public interface HttpProxyServerBootstrap {
      * @return
      */
     HttpProxyServerBootstrap withUnrecoverableFailureHttpResponseComposer(
-        FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer);
+        ServerConnectionFailureHttpResponseComposer unrecoverableFailureHttpResponseComposer);
 
     /**
      * <p>

--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -198,12 +198,20 @@ public interface HttpProxyServerBootstrap {
             HttpFiltersSource filtersSource);
 
     /**
+     * <p>
+     * Specify a {@link FailureHttpResponseComposer} to use for composing
+     * custom response message on unrecoverable failure
+     * </p>
      *
-     * @param unrecoverableFailureHttpResponseComposer
+     * <p>
+     * Default = {@link BadGatewayFailureHttpResponseComposer}
+     * </p>
+     *
+     * @param unrecoverableFailureHttpResponseComposer custom response message composer
      * @return
      */
     HttpProxyServerBootstrap withUnrecoverableFailureHttpResponseComposer(
-        ServerConnectionFailureHttpResponseComposer unrecoverableFailureHttpResponseComposer);
+        FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer);
 
     /**
      * <p>

--- a/src/main/java/org/littleshoot/proxy/ServerConnectionFailureHttpResponseComposer.java
+++ b/src/main/java/org/littleshoot/proxy/ServerConnectionFailureHttpResponseComposer.java
@@ -1,9 +1,0 @@
-package org.littleshoot.proxy;
-
-
-import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpRequest;
-
-public interface ServerConnectionFailureHttpResponseComposer {
-  FullHttpResponse compose(HttpRequest httpRequest, Throwable cause);
-}

--- a/src/main/java/org/littleshoot/proxy/ServerConnectionFailureHttpResponseComposer.java
+++ b/src/main/java/org/littleshoot/proxy/ServerConnectionFailureHttpResponseComposer.java
@@ -4,6 +4,6 @@ package org.littleshoot.proxy;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpRequest;
 
-public interface FailureHttpResponseComposer {
+public interface ServerConnectionFailureHttpResponseComposer {
   FullHttpResponse compose(HttpRequest httpRequest, Throwable cause);
 }

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -25,6 +25,8 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import org.apache.commons.lang3.StringUtils;
 import org.littleshoot.proxy.ActivityTracker;
+import org.littleshoot.proxy.BadGatewayFailureHttpResponseComposer;
+import org.littleshoot.proxy.FailureHttpResponseComposer;
 import org.littleshoot.proxy.FlowContext;
 import org.littleshoot.proxy.FullFlowContext;
 import org.littleshoot.proxy.HttpFilters;
@@ -32,7 +34,6 @@ import org.littleshoot.proxy.HttpFiltersAdapter;
 import org.littleshoot.proxy.ProxyAuthenticator;
 import org.littleshoot.proxy.SslEngineSource;
 
-import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -632,7 +633,10 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         serverConnection.disconnect();
         this.serverConnectionsByHostAndPort.remove(serverConnection.getServerHostAndPort());
 
-        boolean keepAlive = writeBadGateway(initialRequest, cause);
+        FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer = proxyServer.getUnrecoverableFailureHttpResponseComposer();
+        FullHttpResponse failureResponse = unrecoverableFailureHttpResponseComposer.compose(initialRequest, cause);
+
+        boolean keepAlive = respondWithShortCircuitResponse(failureResponse);
         if (keepAlive) {
             become(AWAITING_INITIAL);
         } else {
@@ -1195,36 +1199,9 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * Miscellaneous
      **************************************************************************/
 
-    /**
-     * Tells the client that something went wrong trying to proxy its request. If the Bad Gateway is a response to
-     * an HTTP HEAD request, the response will contain no body, but the Content-Length header will be set to the
-     * value it would have been if this 502 Bad Gateway were in response to a GET.
-     *
-     * @param httpRequest the HttpRequest that is resulting in the Bad Gateway response
-     * @return true if the connection will be kept open, or false if it will be disconnected
-     */
-    private boolean writeBadGateway(HttpRequest httpRequest, Throwable cause) {
-        String body = "Bad Gateway: " + httpRequest.getUri();
-        HttpResponseStatus status = HttpResponseStatus.BAD_GATEWAY;
-
-        if (cause instanceof SSLHandshakeException) {
-            final String message = "There was a problem with upstream server certificate";
-            body = message + ": " + httpRequest.getUri();
-            status = new HttpResponseStatus(HttpResponseStatus.BAD_GATEWAY.code(), message);
-        }
-
-        FullHttpResponse response = ProxyUtils.createFullHttpResponse(HttpVersion.HTTP_1_1, status, body);
-
-        if (ProxyUtils.isHEAD(httpRequest)) {
-            // don't allow any body content in response to a HEAD request
-            response.content().clear();
-        }
-
-        return respondWithShortCircuitResponse(response);
-    }
-
     private boolean writeBadGateway (HttpRequest httpRequest) {
-        return writeBadGateway(httpRequest, null);
+        FullHttpResponse badGatewayResponse = new BadGatewayFailureHttpResponseComposer().compose(httpRequest);
+        return respondWithShortCircuitResponse(badGatewayResponse);
     }
 
     /**

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -32,6 +32,7 @@ import org.littleshoot.proxy.HttpFiltersAdapter;
 import org.littleshoot.proxy.ProxyAuthenticator;
 import org.littleshoot.proxy.SslEngineSource;
 
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -616,22 +617,22 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                         serverConnection.getRemoteAddress(),
                         lastStateBeforeFailure,
                         cause);
-                connectionFailedUnrecoverably(initialRequest, serverConnection);
+                connectionFailedUnrecoverably(initialRequest, serverConnection, cause);
                 return false;
             }
         } catch (UnknownHostException uhe) {
-            connectionFailedUnrecoverably(initialRequest, serverConnection);
+            connectionFailedUnrecoverably(initialRequest, serverConnection, cause);
             return false;
         }
     }
 
-    private void connectionFailedUnrecoverably(HttpRequest initialRequest, ProxyToServerConnection serverConnection) {
+    private void connectionFailedUnrecoverably(HttpRequest initialRequest, ProxyToServerConnection serverConnection, Throwable cause) {
         // the connection to the server failed, so disconnect the server and remove the ProxyToServerConnection from the
         // map of open server connections
         serverConnection.disconnect();
         this.serverConnectionsByHostAndPort.remove(serverConnection.getServerHostAndPort());
 
-        boolean keepAlive = writeBadGateway(initialRequest);
+        boolean keepAlive = writeBadGateway(initialRequest, cause);
         if (keepAlive) {
             become(AWAITING_INITIAL);
         } else {
@@ -1202,9 +1203,17 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * @param httpRequest the HttpRequest that is resulting in the Bad Gateway response
      * @return true if the connection will be kept open, or false if it will be disconnected
      */
-    private boolean writeBadGateway(HttpRequest httpRequest) {
+    private boolean writeBadGateway(HttpRequest httpRequest, Throwable cause) {
         String body = "Bad Gateway: " + httpRequest.getUri();
-        FullHttpResponse response = ProxyUtils.createFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_GATEWAY, body);
+        HttpResponseStatus status = HttpResponseStatus.BAD_GATEWAY;
+
+        if (cause instanceof SSLHandshakeException) {
+            final String message = "There was a problem with upstream server certificate";
+            body = message + ": " + httpRequest.getUri();
+            status = new HttpResponseStatus(HttpResponseStatus.BAD_GATEWAY.code(), message);
+        }
+
+        FullHttpResponse response = ProxyUtils.createFullHttpResponse(HttpVersion.HTTP_1_1, status, body);
 
         if (ProxyUtils.isHEAD(httpRequest)) {
             // don't allow any body content in response to a HEAD request
@@ -1212,6 +1221,10 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         }
 
         return respondWithShortCircuitResponse(response);
+    }
+
+    private boolean writeBadGateway (HttpRequest httpRequest) {
+        return writeBadGateway(httpRequest, null);
     }
 
     /**

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -26,7 +26,7 @@ import io.netty.util.concurrent.GenericFutureListener;
 import org.apache.commons.lang3.StringUtils;
 import org.littleshoot.proxy.ActivityTracker;
 import org.littleshoot.proxy.BadGatewayFailureHttpResponseComposer;
-import org.littleshoot.proxy.FailureHttpResponseComposer;
+import org.littleshoot.proxy.ServerConnectionFailureHttpResponseComposer;
 import org.littleshoot.proxy.FlowContext;
 import org.littleshoot.proxy.FullFlowContext;
 import org.littleshoot.proxy.HttpFilters;
@@ -633,7 +633,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         serverConnection.disconnect();
         this.serverConnectionsByHostAndPort.remove(serverConnection.getServerHostAndPort());
 
-        FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer = proxyServer.getUnrecoverableFailureHttpResponseComposer();
+        ServerConnectionFailureHttpResponseComposer unrecoverableFailureHttpResponseComposer = proxyServer.getUnrecoverableFailureHttpResponseComposer();
         FullHttpResponse failureResponse = unrecoverableFailureHttpResponseComposer.compose(initialRequest, cause);
 
         boolean keepAlive = respondWithShortCircuitResponse(failureResponse);

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -27,7 +27,7 @@ import org.littleshoot.proxy.HttpFiltersSource;
 import org.littleshoot.proxy.HttpFiltersSourceAdapter;
 import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.HttpProxyServerBootstrap;
-import org.littleshoot.proxy.FailureHttpResponseComposer;
+import org.littleshoot.proxy.ServerConnectionFailureHttpResponseComposer;
 import org.littleshoot.proxy.MitmManager;
 import org.littleshoot.proxy.ProxyAuthenticator;
 import org.littleshoot.proxy.SslEngineSource;
@@ -110,7 +110,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
     private final ChainedProxyManager chainProxyManager;
     private final MitmManager mitmManager;
     private final HttpFiltersSource filtersSource;
-    private final FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer;
+    private final ServerConnectionFailureHttpResponseComposer unrecoverableFailureHttpResponseComposer;
     private final boolean transparent;
     private volatile int connectTimeout;
     private volatile int idleConnectionTimeout;
@@ -243,7 +243,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             ChainedProxyManager chainProxyManager,
             MitmManager mitmManager,
             HttpFiltersSource filtersSource,
-            FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer,
+            ServerConnectionFailureHttpResponseComposer unrecoverableFailureHttpResponseComposer,
             boolean transparent,
             int idleConnectionTimeout,
             Collection<ActivityTracker> activityTrackers,
@@ -591,7 +591,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         return filtersSource;
     }
 
-    public FailureHttpResponseComposer getUnrecoverableFailureHttpResponseComposer() {
+    public ServerConnectionFailureHttpResponseComposer getUnrecoverableFailureHttpResponseComposer() {
         return unrecoverableFailureHttpResponseComposer;
     }
 
@@ -622,7 +622,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         private ChainedProxyManager chainProxyManager = null;
         private MitmManager mitmManager = null;
         private HttpFiltersSource filtersSource = new HttpFiltersSourceAdapter();
-        private FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer = new BadGatewayFailureHttpResponseComposer();
+        private ServerConnectionFailureHttpResponseComposer unrecoverableFailureHttpResponseComposer = new BadGatewayFailureHttpResponseComposer();
         private boolean transparent = false;
         private int idleConnectionTimeout = 70;
         private Collection<ActivityTracker> activityTrackers = new ConcurrentLinkedQueue<ActivityTracker>();
@@ -653,7 +653,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
                 ChainedProxyManager chainProxyManager,
                 MitmManager mitmManager,
                 HttpFiltersSource filtersSource,
-                FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer,
+                ServerConnectionFailureHttpResponseComposer unrecoverableFailureHttpResponseComposer,
                 boolean transparent, int idleConnectionTimeout,
                 Collection<ActivityTracker> activityTrackers,
                 int connectTimeout, HostResolver serverResolver,
@@ -815,7 +815,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         }
 
         public HttpProxyServerBootstrap withUnrecoverableFailureHttpResponseComposer(
-            FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer) {
+            ServerConnectionFailureHttpResponseComposer unrecoverableFailureHttpResponseComposer) {
             this.unrecoverableFailureHttpResponseComposer = unrecoverableFailureHttpResponseComposer;
             return this;
         }

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -17,6 +17,7 @@ import io.netty.channel.udt.nio.NioUdtProvider;
 import io.netty.handler.traffic.GlobalTrafficShapingHandler;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.littleshoot.proxy.ActivityTracker;
+import org.littleshoot.proxy.BadGatewayFailureHttpResponseComposer;
 import org.littleshoot.proxy.ChainedProxyManager;
 import org.littleshoot.proxy.DefaultHostResolver;
 import org.littleshoot.proxy.DnsSecServerResolver;
@@ -26,6 +27,7 @@ import org.littleshoot.proxy.HttpFiltersSource;
 import org.littleshoot.proxy.HttpFiltersSourceAdapter;
 import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.HttpProxyServerBootstrap;
+import org.littleshoot.proxy.FailureHttpResponseComposer;
 import org.littleshoot.proxy.MitmManager;
 import org.littleshoot.proxy.ProxyAuthenticator;
 import org.littleshoot.proxy.SslEngineSource;
@@ -108,6 +110,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
     private final ChainedProxyManager chainProxyManager;
     private final MitmManager mitmManager;
     private final HttpFiltersSource filtersSource;
+    private final FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer;
     private final boolean transparent;
     private volatile int connectTimeout;
     private volatile int idleConnectionTimeout;
@@ -240,6 +243,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             ChainedProxyManager chainProxyManager,
             MitmManager mitmManager,
             HttpFiltersSource filtersSource,
+            FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer,
             boolean transparent,
             int idleConnectionTimeout,
             Collection<ActivityTracker> activityTrackers,
@@ -262,6 +266,11 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         this.chainProxyManager = chainProxyManager;
         this.mitmManager = mitmManager;
         this.filtersSource = filtersSource;
+        if (unrecoverableFailureHttpResponseComposer == null) {
+            this.unrecoverableFailureHttpResponseComposer = new BadGatewayFailureHttpResponseComposer();
+        } else {
+            this.unrecoverableFailureHttpResponseComposer = unrecoverableFailureHttpResponseComposer;
+        }
         this.transparent = transparent;
         this.idleConnectionTimeout = idleConnectionTimeout;
         if (activityTrackers != null) {
@@ -396,6 +405,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
                     chainProxyManager,
                     mitmManager,
                     filtersSource,
+                    unrecoverableFailureHttpResponseComposer,
                     transparent,
                     idleConnectionTimeout,
                     activityTrackers,
@@ -581,6 +591,10 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         return filtersSource;
     }
 
+    public FailureHttpResponseComposer getUnrecoverableFailureHttpResponseComposer() {
+        return unrecoverableFailureHttpResponseComposer;
+    }
+
     protected Collection<ActivityTracker> getActivityTrackers() {
         return activityTrackers;
     }
@@ -608,6 +622,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         private ChainedProxyManager chainProxyManager = null;
         private MitmManager mitmManager = null;
         private HttpFiltersSource filtersSource = new HttpFiltersSourceAdapter();
+        private FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer = new BadGatewayFailureHttpResponseComposer();
         private boolean transparent = false;
         private int idleConnectionTimeout = 70;
         private Collection<ActivityTracker> activityTrackers = new ConcurrentLinkedQueue<ActivityTracker>();
@@ -638,6 +653,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
                 ChainedProxyManager chainProxyManager,
                 MitmManager mitmManager,
                 HttpFiltersSource filtersSource,
+                FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer,
                 boolean transparent, int idleConnectionTimeout,
                 Collection<ActivityTracker> activityTrackers,
                 int connectTimeout, HostResolver serverResolver,
@@ -659,6 +675,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             this.chainProxyManager = chainProxyManager;
             this.mitmManager = mitmManager;
             this.filtersSource = filtersSource;
+            this.unrecoverableFailureHttpResponseComposer = unrecoverableFailureHttpResponseComposer;
             this.transparent = transparent;
             this.idleConnectionTimeout = idleConnectionTimeout;
             if (activityTrackers != null) {
@@ -797,6 +814,12 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             return this;
         }
 
+        public HttpProxyServerBootstrap withUnrecoverableFailureHttpResponseComposer(
+            FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer) {
+            this.unrecoverableFailureHttpResponseComposer = unrecoverableFailureHttpResponseComposer;
+            return this;
+        }
+
         @Override
         public HttpProxyServerBootstrap withUseDnsSec(boolean useDnsSec) {
             if (useDnsSec) {
@@ -900,7 +923,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
                     transportProtocol, determineListenAddress(),
                     sslEngineSource, authenticateSslClients,
                     proxyAuthenticator, chainProxyManager, mitmManager,
-                    filtersSource, transparent,
+                    filtersSource, unrecoverableFailureHttpResponseComposer, transparent,
                     idleConnectionTimeout, activityTrackers, connectTimeout,
                     serverResolver, readThrottleBytesPerSecond, writeThrottleBytesPerSecond,
                     localAddress, proxyAlias, maxInitialLineLength, maxHeaderSize, maxChunkSize,

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -266,11 +266,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         this.chainProxyManager = chainProxyManager;
         this.mitmManager = mitmManager;
         this.filtersSource = filtersSource;
-        if (unrecoverableFailureHttpResponseComposer == null) {
-            this.unrecoverableFailureHttpResponseComposer = new BadGatewayFailureHttpResponseComposer();
-        } else {
-            this.unrecoverableFailureHttpResponseComposer = unrecoverableFailureHttpResponseComposer;
-        }
+        this.unrecoverableFailureHttpResponseComposer = unrecoverableFailureHttpResponseComposer;
         this.transparent = transparent;
         this.idleConnectionTimeout = idleConnectionTimeout;
         if (activityTrackers != null) {

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -27,7 +27,7 @@ import org.littleshoot.proxy.HttpFiltersSource;
 import org.littleshoot.proxy.HttpFiltersSourceAdapter;
 import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.HttpProxyServerBootstrap;
-import org.littleshoot.proxy.ServerConnectionFailureHttpResponseComposer;
+import org.littleshoot.proxy.FailureHttpResponseComposer;
 import org.littleshoot.proxy.MitmManager;
 import org.littleshoot.proxy.ProxyAuthenticator;
 import org.littleshoot.proxy.SslEngineSource;
@@ -110,7 +110,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
     private final ChainedProxyManager chainProxyManager;
     private final MitmManager mitmManager;
     private final HttpFiltersSource filtersSource;
-    private final ServerConnectionFailureHttpResponseComposer unrecoverableFailureHttpResponseComposer;
+    private final FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer;
     private final boolean transparent;
     private volatile int connectTimeout;
     private volatile int idleConnectionTimeout;
@@ -243,7 +243,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             ChainedProxyManager chainProxyManager,
             MitmManager mitmManager,
             HttpFiltersSource filtersSource,
-            ServerConnectionFailureHttpResponseComposer unrecoverableFailureHttpResponseComposer,
+            FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer,
             boolean transparent,
             int idleConnectionTimeout,
             Collection<ActivityTracker> activityTrackers,
@@ -587,7 +587,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         return filtersSource;
     }
 
-    public ServerConnectionFailureHttpResponseComposer getUnrecoverableFailureHttpResponseComposer() {
+    public FailureHttpResponseComposer getUnrecoverableFailureHttpResponseComposer() {
         return unrecoverableFailureHttpResponseComposer;
     }
 
@@ -618,7 +618,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         private ChainedProxyManager chainProxyManager = null;
         private MitmManager mitmManager = null;
         private HttpFiltersSource filtersSource = new HttpFiltersSourceAdapter();
-        private ServerConnectionFailureHttpResponseComposer unrecoverableFailureHttpResponseComposer = new BadGatewayFailureHttpResponseComposer();
+        private FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer = new BadGatewayFailureHttpResponseComposer();
         private boolean transparent = false;
         private int idleConnectionTimeout = 70;
         private Collection<ActivityTracker> activityTrackers = new ConcurrentLinkedQueue<ActivityTracker>();
@@ -649,7 +649,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
                 ChainedProxyManager chainProxyManager,
                 MitmManager mitmManager,
                 HttpFiltersSource filtersSource,
-                ServerConnectionFailureHttpResponseComposer unrecoverableFailureHttpResponseComposer,
+                FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer,
                 boolean transparent, int idleConnectionTimeout,
                 Collection<ActivityTracker> activityTrackers,
                 int connectTimeout, HostResolver serverResolver,
@@ -811,7 +811,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         }
 
         public HttpProxyServerBootstrap withUnrecoverableFailureHttpResponseComposer(
-            ServerConnectionFailureHttpResponseComposer unrecoverableFailureHttpResponseComposer) {
+            FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer) {
             this.unrecoverableFailureHttpResponseComposer = unrecoverableFailureHttpResponseComposer;
             return this;
         }

--- a/src/test/java/org/littleshoot/proxy/BadGatewayFailureHttpResponseComposerTest.java
+++ b/src/test/java/org/littleshoot/proxy/BadGatewayFailureHttpResponseComposerTest.java
@@ -1,0 +1,49 @@
+package org.littleshoot.proxy;
+
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpRequest;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class BadGatewayFailureHttpResponseComposerTest {
+
+  private static final String REQUEST_URI = "https://localhost/hi";
+
+  @Test
+  public void testDefault() throws IOException {
+    FailureHttpResponseComposer badGatewayResponseComposer = new BadGatewayFailureHttpResponseComposer();
+
+    HttpRequest initialRequest = mock(HttpRequest.class);
+    when(initialRequest.getUri()).thenReturn(REQUEST_URI);
+
+    FullHttpResponse response = badGatewayResponseComposer.compose(initialRequest, new RuntimeException());
+
+    assertEquals(502, response.getStatus().code());
+    assertEquals("Bad Gateway", response.getStatus().reasonPhrase());
+    assertEquals("Bad Gateway: " + REQUEST_URI, new String(response.content().array()));
+  }
+
+  @Test
+  public void testCustomMessage() throws IOException {
+    FailureHttpResponseComposer badGatewayResponseComposer = new BadGatewayFailureHttpResponseComposer() {
+      @Override
+      protected String provideCustomMessage(HttpRequest httpRequest, Throwable cause) {
+        return "Invalid certificate: " + httpRequest.getUri();
+      }
+    };
+
+    HttpRequest initialRequest = mock(HttpRequest.class);
+    when(initialRequest.getUri()).thenReturn(REQUEST_URI);
+
+    FullHttpResponse response = badGatewayResponseComposer.compose(initialRequest, new RuntimeException());
+
+    assertEquals(502, response.getStatus().code());
+    assertEquals("Bad Gateway", response.getStatus().reasonPhrase());
+    assertEquals("Invalid certificate: " + REQUEST_URI, new String(response.content().array()));
+  }
+
+}

--- a/src/test/java/org/littleshoot/proxy/BadGatewayFailureHttpResponseComposerTest.java
+++ b/src/test/java/org/littleshoot/proxy/BadGatewayFailureHttpResponseComposerTest.java
@@ -1,6 +1,7 @@
 package org.littleshoot.proxy;
 
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import org.junit.Test;
 
@@ -44,6 +45,30 @@ public class BadGatewayFailureHttpResponseComposerTest {
     assertEquals(502, response.getStatus().code());
     assertEquals("Bad Gateway", response.getStatus().reasonPhrase());
     assertEquals("Invalid certificate: " + REQUEST_URI, new String(response.content().array()));
+  }
+
+  @Test
+  public void testClearedContent() throws IOException {
+    FailureHttpResponseComposer badGatewayResponseComposer = new BadGatewayFailureHttpResponseComposer();
+
+    HttpRequest initialRequest = mock(HttpRequest.class);
+    when(initialRequest.getUri()).thenReturn(REQUEST_URI);
+
+    FullHttpResponse response = badGatewayResponseComposer.compose(initialRequest, new RuntimeException());
+
+    assertEquals(502, response.getStatus().code());
+
+    assertEquals(0, response.content().readerIndex());
+    assertNotEquals(0, response.content().writerIndex());
+
+    when(initialRequest.getMethod()).thenReturn(HttpMethod.HEAD);
+
+    response = badGatewayResponseComposer.compose(initialRequest, new RuntimeException());
+
+    assertEquals(502, response.getStatus().code());
+
+    assertEquals(0, response.content().readerIndex());
+    assertEquals(0, response.content().writerIndex());
   }
 
 }

--- a/src/test/java/org/littleshoot/proxy/impl/DefaultHttpProxyServerTest.java
+++ b/src/test/java/org/littleshoot/proxy/impl/DefaultHttpProxyServerTest.java
@@ -1,0 +1,38 @@
+package org.littleshoot.proxy.impl;
+
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpRequest;
+import org.junit.Test;
+import org.littleshoot.proxy.BadGatewayFailureHttpResponseComposer;
+import org.littleshoot.proxy.ServerConnectionFailureHttpResponseComposer;
+
+import static org.junit.Assert.assertTrue;
+
+public class DefaultHttpProxyServerTest {
+
+  @Test
+  public void testDefaultUnrecoverableFailureHttpResponseComposer() {
+    DefaultHttpProxyServer httpProxyServer = (DefaultHttpProxyServer) DefaultHttpProxyServer.bootstrap().start();
+    assertTrue(httpProxyServer.getUnrecoverableFailureHttpResponseComposer() instanceof BadGatewayFailureHttpResponseComposer);
+    httpProxyServer.stop();
+  }
+
+  @Test
+  public void testCustomUnrecoverableFailureHttpResponseComposer() {
+
+    class CustomUnrecoverableFailureHttpResponseComposer implements ServerConnectionFailureHttpResponseComposer {
+      @Override
+      public FullHttpResponse compose(HttpRequest httpRequest, Throwable cause) {
+        return null;
+      }
+    }
+
+    DefaultHttpProxyServer httpProxyServer = (DefaultHttpProxyServer) DefaultHttpProxyServer
+        .bootstrap()
+        .withUnrecoverableFailureHttpResponseComposer(new CustomUnrecoverableFailureHttpResponseComposer())
+        .start();
+    assertTrue(httpProxyServer.getUnrecoverableFailureHttpResponseComposer() instanceof CustomUnrecoverableFailureHttpResponseComposer);
+    httpProxyServer.stop();
+  }
+
+}

--- a/src/test/java/org/littleshoot/proxy/impl/DefaultHttpProxyServerTest.java
+++ b/src/test/java/org/littleshoot/proxy/impl/DefaultHttpProxyServerTest.java
@@ -4,7 +4,7 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpRequest;
 import org.junit.Test;
 import org.littleshoot.proxy.BadGatewayFailureHttpResponseComposer;
-import org.littleshoot.proxy.ServerConnectionFailureHttpResponseComposer;
+import org.littleshoot.proxy.FailureHttpResponseComposer;
 
 import static org.junit.Assert.assertTrue;
 
@@ -20,7 +20,7 @@ public class DefaultHttpProxyServerTest {
   @Test
   public void testCustomUnrecoverableFailureHttpResponseComposer() {
 
-    class CustomUnrecoverableFailureHttpResponseComposer implements ServerConnectionFailureHttpResponseComposer {
+    class CustomUnrecoverableFailureHttpResponseComposer implements FailureHttpResponseComposer {
       @Override
       public FullHttpResponse compose(HttpRequest httpRequest, Throwable cause) {
         return null;


### PR DESCRIPTION
Prerequisite to https://github.com/verygoodsecurity/vault/pull/1380.

Adds ability to set up a custom http response on upstream server connection failure.