### PR TITLE
Fix NPE in ClientToProxyConnection while closing the client connection

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -866,7 +866,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             }
         }
 
-        if (!HttpHeaders.isKeepAlive(req)) {
+        if (req != null && !HttpHeaders.isKeepAlive(req)) {
             LOG.debug("Closing client connection since request is not keep alive: {}", req);
             // Here we simply want to close the connection because the
             // client itself has requested it be closed in the request.


### PR DESCRIPTION
Fixes https://github.com/verygoodsecurity/vault/issues/1402

Due to currentHttpRequest can be null need to add not null verification, otherwise NPE can occurred.

https://github.com/adamfisk/LittleProxy/blob/master/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java#L290

The currentHttpRequest goes the following route:
1. https://github.com/adamfisk/LittleProxy/blob/master/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java#L519
2. https://github.com/adamfisk/LittleProxy/blob/master/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java#L481
3. https://github.com/adamfisk/LittleProxy/blob/master/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java#L820
4. https://github.com/adamfisk/LittleProxy/blob/master/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java#L822
5. As you can see in shouldCloseClientConnection when response is chunked not-null verification is present
https://github.com/adamfisk/LittleProxy/blob/master/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java#L858

but DOES NOT in keep alive checking 

https://github.com/adamfisk/LittleProxy/blob/master/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java#L869

that's why we got NPE

I've checked all other places where NPE can be raised as well, just need to fix it here.

ProxyToServerConnection

> The current HTTP Request can be null when this proxy is
> negotiating a CONNECT request with a chained proxy
> while it is running as a MITM.