### PR TITLE
Separate global state handler from request tracing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.littleshoot</groupId>
     <artifactId>littleproxy</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.4.0-VGS-SNAPSHOT</version>
+    <version>1.1.5.0-VGS-SNAPSHOT</version>
     <name>LittleProxy</name>
     <description>
         LittleProxy is a high performance HTTP proxy written in Java and using the Netty networking framework.

--- a/src/main/java/org/littleshoot/proxy/GlobalStateHandler.java
+++ b/src/main/java/org/littleshoot/proxy/GlobalStateHandler.java
@@ -14,13 +14,6 @@ import io.netty.channel.Channel;
 public interface GlobalStateHandler {
 
   /**
-   * Serializes global state to channel.
-   *
-   * @param channel client connection channel
-   */
-  void persistToChannel(Channel channel);
-
-  /**
    * Deserializes global state from channel.
    *
    * @param channel client connection channel

--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -211,6 +211,21 @@ public interface HttpProxyServerBootstrap {
     HttpProxyServerBootstrap withProxyToServerExHandler(
         ExceptionHandler proxyToServerExHandler);
 
+
+    /**
+     * <p>
+     * Specify a {@link RequestTracer} to trace proxy requests
+     * </p>
+     *
+     * <p>
+     * Default = null
+     * </p>
+     *
+     * @param requestTracer
+     * @return proxy server bootstrap
+     */
+    HttpProxyServerBootstrap withRequestTracer(RequestTracer requestTracer);
+
     /**
      * <p>
      * Specify an {@link GlobalStateHandler} to customize a global state based on channel attributes

--- a/src/main/java/org/littleshoot/proxy/RequestTracer.java
+++ b/src/main/java/org/littleshoot/proxy/RequestTracer.java
@@ -1,0 +1,18 @@
+package org.littleshoot.proxy;
+
+import io.netty.channel.Channel;
+
+public interface RequestTracer {
+
+  /**
+   * Start tracing proxy request
+   * @param channel
+   */
+  void start(Channel channel);
+
+  /**
+   * Request is served. Finish tracing.
+   * @param channel
+   */
+  void finish(Channel channel);
+}

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -4,7 +4,6 @@ import com.google.common.io.BaseEncoding;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -771,17 +770,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         }
     }
 
-    @Override
-    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
-        try {
-            if (this.proxyServer.getGlobalStateHandler() != null) {
-                this.proxyServer.getGlobalStateHandler().persistToChannel(ctx.channel());
-            }
-        } finally {
-            super.channelRegistered(ctx);
-        }
-    }
-
     /***************************************************************************
      * Connection Management
      **************************************************************************/
@@ -802,6 +790,10 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      */
     private void initChannelPipeline(ChannelPipeline pipeline) {
         LOG.debug("Configuring ChannelPipeline");
+
+        if (proxyServer.getRequestTracer() != null) {
+            pipeline.addLast("requestTracerHandler", new RequestTracerHandler(this));
+        }
 
         if (proxyServer.getGlobalStateHandler() != null) {
             pipeline.addLast("inboundGlobalStateHandler", new InboundGlobalStateHandler(this));

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -33,6 +33,7 @@ import org.littleshoot.proxy.MitmManager;
 import org.littleshoot.proxy.MitmManagerFactory;
 import org.littleshoot.proxy.ProxyAuthenticator;
 import org.littleshoot.proxy.ExceptionHandler;
+import org.littleshoot.proxy.RequestTracer;
 import org.littleshoot.proxy.SslEngineSource;
 import org.littleshoot.proxy.TransportProtocol;
 import org.littleshoot.proxy.UnknownTransportProtocolException;
@@ -114,6 +115,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
     private final MitmManagerFactory mitmManagerFactory;
     private final ExceptionHandler clientToProxyExHandler;
     private final ExceptionHandler proxyToServerExHandler;
+    private final RequestTracer requestTracer;
     private final GlobalStateHandler globalStateHandler;
     private final HttpFiltersSource filtersSource;
     private final FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer;
@@ -250,6 +252,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             MitmManagerFactory mitmManagerFactory,
             ExceptionHandler clientToProxyExHandler,
             ExceptionHandler proxyToServerExHandler,
+            RequestTracer requestTracer,
             GlobalStateHandler globalStateHandler,
             HttpFiltersSource filtersSource,
             FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer,
@@ -276,6 +279,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         this.mitmManagerFactory = mitmManagerFactory;
         this.clientToProxyExHandler = clientToProxyExHandler;
         this.proxyToServerExHandler = proxyToServerExHandler;
+        this.requestTracer = requestTracer;
         this.globalStateHandler = globalStateHandler;
         this.filtersSource = filtersSource;
         this.unrecoverableFailureHttpResponseComposer = unrecoverableFailureHttpResponseComposer;
@@ -414,6 +418,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
                     mitmManagerFactory,
                     clientToProxyExHandler,
                     proxyToServerExHandler,
+                    requestTracer,
                     globalStateHandler,
                     filtersSource,
                     unrecoverableFailureHttpResponseComposer,
@@ -605,6 +610,10 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         return globalStateHandler;
     }
 
+    protected RequestTracer getRequestTracer() {
+        return requestTracer;
+    }
+
     protected SslEngineSource getSslEngineSource() {
         return sslEngineSource;
     }
@@ -649,6 +658,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         private MitmManagerFactory mitmManagerFactory = null;
         private ExceptionHandler clientToProxyExHandler = null;
         private ExceptionHandler proxyToServerExHandler = null;
+        private RequestTracer requestTracer = null;
         private GlobalStateHandler globalStateHandler = null;
         private HttpFiltersSource filtersSource = new HttpFiltersSourceAdapter();
         private FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer = new DefaultFailureHttpResponseComposer();
@@ -683,6 +693,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
                 MitmManagerFactory mitmManagerFactory,
                 ExceptionHandler clientToProxyExHandler,
                 ExceptionHandler proxyToServerExHandler,
+                RequestTracer requestTracer,
                 GlobalStateHandler globalStateHandler,
                 HttpFiltersSource filtersSource,
                 FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer,
@@ -708,6 +719,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             this.mitmManagerFactory = mitmManagerFactory;
             this.clientToProxyExHandler = clientToProxyExHandler;
             this.proxyToServerExHandler = proxyToServerExHandler;
+            this.requestTracer = requestTracer;
             this.globalStateHandler = globalStateHandler;
             this.filtersSource = filtersSource;
             this.unrecoverableFailureHttpResponseComposer = unrecoverableFailureHttpResponseComposer;
@@ -857,12 +869,18 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         }
 
         @Override
+        public HttpProxyServerBootstrap withRequestTracer(
+            RequestTracer requestTracer) {
+            this.requestTracer = requestTracer;
+            return this;
+        }
+
+        @Override
         public HttpProxyServerBootstrap withCustomGlobalState(
             GlobalStateHandler globalStateHandler) {
             this.globalStateHandler = globalStateHandler;
             return this;
         }
-
 
         @Override
         public HttpProxyServerBootstrap withFiltersSource(
@@ -980,7 +998,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
                     transportProtocol, determineListenAddress(),
                     sslEngineSource, authenticateSslClients,
                     proxyAuthenticator, chainProxyManager, mitmManagerFactory,
-                    clientToProxyExHandler, proxyToServerExHandler, globalStateHandler,
+                    clientToProxyExHandler, proxyToServerExHandler, requestTracer, globalStateHandler,
                     filtersSource, unrecoverableFailureHttpResponseComposer, transparent,
                     idleConnectionTimeout, activityTrackers, connectTimeout,
                     serverResolver, readThrottleBytesPerSecond, writeThrottleBytesPerSecond,

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -756,8 +756,11 @@ abstract class ProxyConnection<I extends HttpObject> extends
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg)
             throws Exception {
-            proxyServer.getRequestTracer().start(clientToProxyConnection.channel);
-            super.channelRead(ctx, msg);
+            try {
+                proxyServer.getRequestTracer().start(clientToProxyConnection.channel);
+            } finally {
+                super.channelRead(ctx, msg);
+            }
         }
 
         @Override

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -753,10 +753,11 @@ abstract class ProxyConnection<I extends HttpObject> extends
         }
 
         @Override
-        public void channelRead(ChannelHandlerContext ctx, Object msg)
-            throws Exception {
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
             try {
                 proxyServer.getRequestTracer().start(clientToProxyConnection.channel);
+            } catch (Throwable t) {
+                LOG.warn("Unable to start tracing request", t);
             } finally {
                 super.channelRead(ctx, msg);
             }
@@ -764,8 +765,7 @@ abstract class ProxyConnection<I extends HttpObject> extends
 
         @Override
         public void write(ChannelHandlerContext ctx,
-                          Object msg, ChannelPromise promise)
-            throws Exception {
+                          Object msg, ChannelPromise promise) throws Exception {
             try {
                 super.write(ctx, msg, promise);
             } finally {

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -744,8 +744,7 @@ abstract class ProxyConnection<I extends HttpObject> extends
     }
 
     @Sharable
-    protected class RequestTracerHandler extends
-        ChannelDuplexHandler {
+    protected class RequestTracerHandler extends ChannelDuplexHandler {
 
         private final ProxyConnection<HttpRequest> clientToProxyConnection;
 

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -769,7 +769,11 @@ abstract class ProxyConnection<I extends HttpObject> extends
             try {
                 super.write(ctx, msg, promise);
             } finally {
-                proxyServer.getRequestTracer().finish(clientToProxyConnection.channel);
+                try {
+                    proxyServer.getRequestTracer().finish(clientToProxyConnection.channel);
+                } catch (Throwable t) {
+                    LOG.warn("Unable to finish request tracing", t);
+                }
             }
         }
     }


### PR DESCRIPTION
## Follow-up to #19

We can not start tracing on channel registered as it is reused by different requests when a connection is kept alive. It means many requests will have the same trace id. It also means attributes are shared but as I understand there will never be a contention as a client will need to wait for a request to finish before sending another one with the same kept alive connection.