### PR TITLE
Restore global state on triggered event

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.littleshoot</groupId>
     <artifactId>littleproxy</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.5.0-VGS-SNAPSHOT</version>
+    <version>1.1.5.1-VGS-SNAPSHOT</version>
     <name>LittleProxy</name>
     <description>
         LittleProxy is a high performance HTTP proxy written in Java and using the Netty networking framework.

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -661,12 +661,14 @@ abstract class ProxyConnection<I extends HttpObject> extends
     public final void userEventTriggered(ChannelHandlerContext ctx, Object evt)
             throws Exception {
         try {
+            proxyServer.getGlobalStateHandler().restoreFromChannel(ctx.channel());
             if (evt instanceof IdleStateEvent) {
                 LOG.debug("Got idle");
                 timedOut();
             }
         } finally {
             super.userEventTriggered(ctx, evt);
+            proxyServer.getGlobalStateHandler().clear();
         }
     }
 


### PR DESCRIPTION
When a connection is timed out a user even is triggered which calls timeout() method which runs `clientToProxyResponse` method where tenant information is required. This is a separate path from read/write to channel so `restoreFromChannel` is not called in this exceptional situation. We need to handle it here as well. 