### PR TITLE
Async message processing logic

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -245,11 +245,11 @@ public interface HttpProxyServerBootstrap {
 
     /**
      *
-     * @param payloadProcessorExecutor
+     * @param messageProcessorExecutor
      * @return
      */
-    HttpProxyServerBootstrap withPyaloadProcessorExecutor(
-        ExecutorService payloadProcessorExecutor);
+    HttpProxyServerBootstrap withMessageProcessingExecutor(
+        ExecutorService messageProcessorExecutor);
 
     /**
      * <p>

--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -4,6 +4,7 @@ import org.littleshoot.proxy.impl.ThreadPoolConfiguration;
 import org.littleshoot.proxy.ratelimit.RateLimiter;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Configures and starts an {@link HttpProxyServer}. The HttpProxyServer is
@@ -241,6 +242,14 @@ public interface HttpProxyServerBootstrap {
      */
     HttpProxyServerBootstrap withCustomGlobalState(
         GlobalStateHandler globalStateHandler);
+
+    /**
+     *
+     * @param payloadProcessorExecutor
+     * @return
+     */
+    HttpProxyServerBootstrap withPyaloadProcessorExecutor(
+        ExecutorService payloadProcessorExecutor);
 
     /**
      * <p>

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -900,7 +900,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             pipeline.addLast("outboundGlobalStateHandler", new OutboundGlobalStateHandler(this));
         }
 
-        pipeline.addLast(globalStateWrapperEvenLoop,  "handler", this);
+        pipeline.addLast(globalStateWrapperEvenLoop,  "router", this);
         pipeline.addLast(globalStateWrapperEvenLoop,  "httpInitialHandler", new HttpInitialHandler<>(this));
         pipeline.addLast(globalStateWrapperEvenLoop,  "clientToProxyMessageProcessor", new ClientToProxyMessageProcessor());
         pipeline.addLast(globalStateWrapperEvenLoop,  "upstreamConnectionHandler", new UpstreamConnectionHandler(this));

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -900,8 +900,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         }
 
         pipeline.addLast(globalStateWrapperEvenLoop,  "handler", this);
-        HttpInitialHandler<HttpRequest> httpInitialHandler = new HttpInitialHandler<>(this);
-        pipeline.addLast(globalStateWrapperEvenLoop,  "httpInitialHandler", httpInitialHandler);
+        pipeline.addLast(globalStateWrapperEvenLoop,  "httpInitialHandler", new HttpInitialHandler<>(this));
         pipeline.addLast(globalStateWrapperEvenLoop,  "clientToProxyMessageProcessor", new ClientToProxyMessageProcessor());
         pipeline.addLast(globalStateWrapperEvenLoop,  "upstreamConnectionHandler", new UpstreamConnectionHandler(this));
 

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -352,7 +352,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     }
 
     @Sharable
-    protected class ClientToProxyProcessor extends ChannelDuplexHandler {
+    protected class ClientPayloadProcessor extends ChannelDuplexHandler {
 
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
@@ -922,7 +922,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
         pipeline.addLast(globalStateWrapperEvenLoop, "handlerBegin", this);
 
-        pipeline.addLast(globalStateWrapperEvenLoop, "clientToProxyProcessor", new ClientToProxyProcessor());
+        pipeline.addLast(globalStateWrapperEvenLoop, "clientToProxyProcessor", new ClientPayloadProcessor());
 
         pipeline.addLast(globalStateWrapperEvenLoop, "handlerEnd", this);
 

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -28,7 +28,6 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.handler.traffic.GlobalTrafficShapingHandler;
 import io.netty.util.ReferenceCounted;
-import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import org.apache.commons.lang3.StringUtils;
@@ -54,8 +53,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -354,8 +351,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         }
     }
 
-    private static final Executor executor = Executors.newCachedThreadPool();
-
     @Sharable
     protected class ClientToProxyProcessor extends ChannelDuplexHandler {
 
@@ -372,7 +367,8 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
           if (ProxyUtils.isChunked(httpRequest)) {
               process(ctx, msg, httpRequest);
           } else {
-              executor.execute(wrapTask(() -> process(ctx, msg, httpRequest)));
+              proxyServer.getPayloadProcessorExecutor()
+                  .execute(wrapTask(() -> process(ctx, msg, httpRequest)));
           }
 
         }

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -213,7 +213,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
           ctx.fireChannelRead(httpRequest);
         }
 
-        return state();
+        return getCurrentState();
     }
 
     /**
@@ -386,6 +386,11 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
                 // Send the request through the clientToProxyRequest filter, and respond with the short-circuit response if required
                 clientToProxyResponse = currentFilters.clientToProxyRequest(httpRequest);
+
+                if (msg instanceof ReferenceCounted) {
+                    LOG.debug("Retaining reference counted message");
+                    ((ReferenceCounted) msg).retain();
+                }
 
                 ctx.fireChannelRead(httpRequest);
 //            });

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -362,7 +362,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
 
-            executor.execute(() -> {
+//            executor.execute(() -> {
                 HttpRequest httpRequest = (HttpRequest) msg;
                 // Make a copy of the original request
                 final HttpRequest currentRequest = copy(httpRequest);
@@ -388,7 +388,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                 clientToProxyResponse = currentFilters.clientToProxyRequest(httpRequest);
 
                 ctx.fireChannelRead(httpRequest);
-            });
+//            });
 
         }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -406,6 +406,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                     LOG.debug("Retaining reference counted message");
                     ((ReferenceCounted) httpRequest).release();
                 }
+                ctx.fireExceptionCaught(e);
             }
 
             if (!authenticationRequired) {

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -372,7 +372,14 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
           if (ProxyUtils.isChunked(httpRequest)) {
               process(ctx, msg, httpRequest);
           } else {
-              executor.execute(() -> process(ctx, msg, httpRequest));
+              executor.execute(() -> {
+                  proxyServer.getGlobalStateHandler().restoreFromChannel(channel);
+                  try {
+                      process(ctx, msg, httpRequest);
+                  } finally {
+                      proxyServer.getGlobalStateHandler().clear();
+                  }
+              });
           }
 
         }

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -3,11 +3,10 @@ package org.littleshoot.proxy.impl;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultEventLoop;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
@@ -145,7 +144,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
     private AtomicBoolean authenticated = new AtomicBoolean();
 
-    public HttpResponse clientToProxyResponse;
+    private HttpResponse clientToProxyResponse;
 
     private final GlobalTrafficShapingHandler globalTrafficShapingHandler;
 
@@ -352,10 +351,10 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     }
 
     @Sharable
-    protected class ClientPayloadProcessor extends ChannelDuplexHandler {
+    protected class ClientPayloadProcessor extends ChannelInboundHandlerAdapter {
 
         @Override
-        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
 
           if (msg instanceof ReferenceCounted) {
             LOG.debug("Retaining reference counted message");
@@ -412,12 +411,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
               ctx.fireChannelRead(httpRequest);
             }
-        }
-
-        @Override
-        public void write(ChannelHandlerContext ctx,
-                          Object msg, ChannelPromise promise) throws Exception {
-          super.write(ctx, msg, promise);
         }
     }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -861,7 +861,11 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             pipeline.addLast("requestTracerHandler", new RequestTracerHandler(this));
         }
 
-        final EventExecutorGroup globalStateWrapperEvenLoop = new GlobalStateWrapperEvenLoop(this);
+        if (proxyServer.getGlobalStateHandler() != null) {
+          pipeline.addLast("inboundGlobalStateHandler", new InboundGlobalStateHandler(this));
+        }
+
+        EventExecutorGroup globalStateWrapperEvenLoop = new GlobalStateWrapperEvenLoop(this);
 
         pipeline.addLast(globalStateWrapperEvenLoop, "bytesReadMonitor", bytesReadMonitor);
         pipeline.addLast(globalStateWrapperEvenLoop, "bytesWrittenMonitor", bytesWrittenMonitor);
@@ -888,6 +892,10 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                 "idle",
                 new IdleStateHandler(0, 0, proxyServer
                         .getIdleConnectionTimeout()));
+
+        if (proxyServer.getGlobalStateHandler() != null) {
+          pipeline.addLast("outboundGlobalStateHandler", new OutboundGlobalStateHandler(this));
+        }
 
         pipeline.addLast(globalStateWrapperEvenLoop,  "handlerBegin", this);
 

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -861,11 +861,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             pipeline.addLast("requestTracerHandler", new RequestTracerHandler(this));
         }
 
-//        if (proxyServer.getGlobalStateHandler() != null) {
-//          pipeline.addLast("inboundGlobalStateHandler", new InboundGlobalStateHandler(this));
-//        }
-
-        EventExecutorGroup globalStateWrapperEvenLoop = new GlobalStateWrapperEvenLoop(this);
+        final EventExecutorGroup globalStateWrapperEvenLoop = new GlobalStateWrapperEvenLoop(this);
 
         pipeline.addLast(globalStateWrapperEvenLoop, "bytesReadMonitor", bytesReadMonitor);
         pipeline.addLast(globalStateWrapperEvenLoop, "bytesWrittenMonitor", bytesWrittenMonitor);
@@ -892,10 +888,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                 "idle",
                 new IdleStateHandler(0, 0, proxyServer
                         .getIdleConnectionTimeout()));
-
-//        if (proxyServer.getGlobalStateHandler() != null) {
-//          pipeline.addLast("outboundGlobalStateHandler", new OutboundGlobalStateHandler(this));
-//        }
 
         pipeline.addLast(globalStateWrapperEvenLoop,  "handlerBegin", this);
 

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -887,8 +887,8 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
         EventLoopGroup globalStateWrapperEvenLoop = new GlobalStateWrapperEvenLoop(channel.eventLoop());
 
-        pipeline.addLast(globalStateWrapperEvenLoop, "bytesReadMonitor", bytesReadMonitor);
-        pipeline.addLast(globalStateWrapperEvenLoop, "bytesWrittenMonitor", bytesWrittenMonitor);
+        pipeline.addLast( "bytesReadMonitor", bytesReadMonitor);
+        pipeline.addLast( "bytesWrittenMonitor", bytesWrittenMonitor);
 
         pipeline.addLast("encoder", new HttpResponseEncoder());
         // We want to allow longer request lines, headers, and chunks
@@ -905,19 +905,19 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             aggregateContentForFiltering(pipeline, numberOfBytesToBuffer);
         }
 
-        pipeline.addLast(globalStateWrapperEvenLoop, "requestReadMonitor", requestReadMonitor);
-        pipeline.addLast(globalStateWrapperEvenLoop, "responseWrittenMonitor", responseWrittenMonitor);
+        pipeline.addLast( "requestReadMonitor", requestReadMonitor);
+        pipeline.addLast( "responseWrittenMonitor", responseWrittenMonitor);
 
         pipeline.addLast(
                 "idle",
                 new IdleStateHandler(0, 0, proxyServer
                         .getIdleConnectionTimeout()));
 
-        pipeline.addLast(globalStateWrapperEvenLoop, "handlerBegin", this);
+        pipeline.addLast( "handlerBegin", this);
 
-        pipeline.addLast(globalStateWrapperEvenLoop, "clientToProxyProcessor", new ClientPayloadProcessor());
+        pipeline.addLast( "clientToProxyProcessor", new ClientPayloadProcessor());
 
-        pipeline.addLast(globalStateWrapperEvenLoop, "handlerEnd", this);
+        pipeline.addLast( "handlerEnd", this);
 
     }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -887,8 +887,8 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
         EventLoopGroup globalStateWrapperEvenLoop = new GlobalStateWrapperEvenLoop(channel.eventLoop());
 
-        pipeline.addLast( "bytesReadMonitor", bytesReadMonitor);
-        pipeline.addLast( "bytesWrittenMonitor", bytesWrittenMonitor);
+        pipeline.addLast(globalStateWrapperEvenLoop, "bytesReadMonitor", bytesReadMonitor);
+        pipeline.addLast(globalStateWrapperEvenLoop, "bytesWrittenMonitor", bytesWrittenMonitor);
 
         pipeline.addLast("encoder", new HttpResponseEncoder());
         // We want to allow longer request lines, headers, and chunks
@@ -905,8 +905,8 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             aggregateContentForFiltering(pipeline, numberOfBytesToBuffer);
         }
 
-        pipeline.addLast( "requestReadMonitor", requestReadMonitor);
-        pipeline.addLast( "responseWrittenMonitor", responseWrittenMonitor);
+        pipeline.addLast(globalStateWrapperEvenLoop, "requestReadMonitor", requestReadMonitor);
+        pipeline.addLast(globalStateWrapperEvenLoop, "responseWrittenMonitor", responseWrittenMonitor);
 
         pipeline.addLast(
                 "idle",

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -407,6 +407,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                     ((ReferenceCounted) httpRequest).release();
                 }
                 ctx.fireExceptionCaught(e);
+                return;
             }
 
             if (!authenticationRequired) {

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -412,13 +412,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         @Override
         public void write(ChannelHandlerContext ctx,
                           Object msg, ChannelPromise promise) throws Exception {
-            HttpObject httpObject = ((HttpObject)msg);
-            httpObject = currentFilters.proxyToClientResponse(httpObject);
-            if (httpObject == null) {
-                forceDisconnect(currentServerConnection);
-            } else {
-                super.write(ctx, msg, promise);
-            }
+          super.write(ctx, msg, promise);
         }
     }
 
@@ -523,6 +517,12 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
             fixHttpVersionHeaderIfNecessary(httpResponse);
             modifyResponseHeadersToReflectProxying(httpResponse);
+        }
+
+        httpObject = filters.proxyToClientResponse(httpObject);
+        if (httpObject == null) {
+            forceDisconnect(serverConnection);
+            return;
         }
 
         write(httpObject);

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -864,7 +864,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         }
 
         if (proxyServer.getGlobalStateHandler() != null) {
-          pipeline.addLast("inboundGlobalStateHandler", new InboundGlobalStateHandler(this));
+            pipeline.addLast("inboundGlobalStateHandler", new InboundGlobalStateHandler(this));
         }
 
         EventExecutorGroup globalStateWrapperEvenLoop = new GlobalStateWrapperEvenLoop(this);
@@ -896,7 +896,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                         .getIdleConnectionTimeout()));
 
         if (proxyServer.getGlobalStateHandler() != null) {
-          pipeline.addLast("outboundGlobalStateHandler", new OutboundGlobalStateHandler(this));
+            pipeline.addLast("outboundGlobalStateHandler", new OutboundGlobalStateHandler(this));
         }
 
         pipeline.addLast(globalStateWrapperEvenLoop,  "handler", this);

--- a/src/main/java/org/littleshoot/proxy/impl/ConnectionState.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ConnectionState.java
@@ -6,6 +6,8 @@ enum ConnectionState {
      */
     CONNECTING(true),
 
+    CLIENT_TO_PROXY_PROCESSING,
+
     /**
      * In the middle of doing an SSL handshake.
      */

--- a/src/main/java/org/littleshoot/proxy/impl/ConnectionState.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ConnectionState.java
@@ -6,8 +6,6 @@ enum ConnectionState {
      */
     CONNECTING(true),
 
-    CLIENT_TO_PROXY_PROCESSING,
-
     /**
      * In the middle of doing an SSL handshake.
      */

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -626,7 +626,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
     }
 
     protected ExecutorService getPayloadProcessorExecutor() {
-        return payloadProcessorExecutor;
+        return serverGroup.getPayloadProcessingExecutor();
     }
 
     protected RequestTracer getRequestTracer() {

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -120,7 +120,6 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
     private final ExceptionHandler proxyToServerExHandler;
     private final RequestTracer requestTracer;
     private final GlobalStateHandler globalStateHandler;
-    private final ExecutorService payloadProcessorExecutor;
     private final HttpFiltersSource filtersSource;
     private final FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer;
     private final boolean transparent;
@@ -259,7 +258,6 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             ExceptionHandler proxyToServerExHandler,
             RequestTracer requestTracer,
             GlobalStateHandler globalStateHandler,
-            ExecutorService payloadProcessorExecutor,
             HttpFiltersSource filtersSource,
             FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer,
             boolean transparent,
@@ -288,7 +286,6 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         this.proxyToServerExHandler = proxyToServerExHandler;
         this.requestTracer = requestTracer;
         this.globalStateHandler = globalStateHandler;
-        this.payloadProcessorExecutor = payloadProcessorExecutor;
         this.filtersSource = filtersSource;
         this.unrecoverableFailureHttpResponseComposer = unrecoverableFailureHttpResponseComposer;
         this.transparent = transparent;
@@ -555,7 +552,6 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
                         DefaultHttpProxyServer.this,
                         sslEngineSource,
                         authenticateSslClients,
-                        ch.pipeline(),
                         globalTrafficShapingHandler,
                         ch);
             };
@@ -625,7 +621,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         return globalStateHandler;
     }
 
-    protected ExecutorService getPayloadProcessorExecutor() {
+    protected ExecutorService getMessageProcessingExecutor() {
         return serverGroup.getMessageProcessingExecutor();
     }
 
@@ -679,7 +675,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         private ExceptionHandler proxyToServerExHandler = null;
         private RequestTracer requestTracer = null;
         private GlobalStateHandler globalStateHandler = null;
-        private ExecutorService payloadProcessorExecutor = null;
+        private ExecutorService messageProcessorExecutor = null;
         private HttpFiltersSource filtersSource = new HttpFiltersSourceAdapter();
         private FailureHttpResponseComposer unrecoverableFailureHttpResponseComposer = new DefaultFailureHttpResponseComposer();
         private boolean transparent = false;
@@ -908,7 +904,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         @Override
         public HttpProxyServerBootstrap withMessageProcessingExecutor(
             ExecutorService messageProcessorExecutor) {
-            this.payloadProcessorExecutor = messageProcessorExecutor;
+            this.messageProcessorExecutor = messageProcessorExecutor;
             return this;
         }
 
@@ -1028,14 +1024,14 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             }
             else {
                 serverGroup = new ServerGroup(name, clientToProxyAcceptorThreads,
-                    clientToProxyWorkerThreads, proxyToServerWorkerThreads, payloadProcessorExecutor);
+                    clientToProxyWorkerThreads, proxyToServerWorkerThreads, messageProcessorExecutor);
             }
 
             return new DefaultHttpProxyServer(serverGroup,
                     transportProtocol, determineListenAddress(),
                     sslEngineSource, authenticateSslClients,
                     proxyAuthenticator, chainProxyManager, mitmManagerFactory,
-                    clientToProxyExHandler, proxyToServerExHandler, requestTracer, globalStateHandler, payloadProcessorExecutor,
+                    clientToProxyExHandler, proxyToServerExHandler, requestTracer, globalStateHandler,
                     filtersSource, unrecoverableFailureHttpResponseComposer, transparent,
                     idleConnectionTimeout, activityTrackers, connectTimeout,
                     serverResolver, readThrottleBytesPerSecond, writeThrottleBytesPerSecond,

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -626,7 +626,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
     }
 
     protected ExecutorService getPayloadProcessorExecutor() {
-        return serverGroup.getPayloadProcessingExecutor();
+        return serverGroup.getMessageProcessingExecutor();
     }
 
     protected RequestTracer getRequestTracer() {
@@ -906,9 +906,9 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         }
 
         @Override
-        public HttpProxyServerBootstrap withPyaloadProcessorExecutor(
-            ExecutorService payloadProcessorExecutor) {
-            this.payloadProcessorExecutor = payloadProcessorExecutor;
+        public HttpProxyServerBootstrap withMessageProcessingExecutor(
+            ExecutorService messageProcessorExecutor) {
+            this.payloadProcessorExecutor = messageProcessorExecutor;
             return this;
         }
 

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -552,7 +552,8 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
                         sslEngineSource,
                         authenticateSslClients,
                         ch.pipeline(),
-                        globalTrafficShapingHandler);
+                        globalTrafficShapingHandler,
+                        ch);
             };
         };
         switch (transportProtocol) {

--- a/src/main/java/org/littleshoot/proxy/impl/GlobalStateWrapperEvenLoop.java
+++ b/src/main/java/org/littleshoot/proxy/impl/GlobalStateWrapperEvenLoop.java
@@ -33,11 +33,7 @@ public class GlobalStateWrapperEvenLoop implements EventExecutor {
 
   @Override
   public void execute(Runnable command) {
-    if (eventLoop.inEventLoop()) {
-      connection.wrapTask(command).run();
-    } else {
-      eventLoop.execute(connection.wrapTask(command));
-    }
+    eventLoop.execute(connection.wrapTask(command));
   }
 
   @Override
@@ -157,7 +153,7 @@ public class GlobalStateWrapperEvenLoop implements EventExecutor {
 
   @Override
   public boolean inEventLoop() {
-    return false;
+    return eventLoop.inEventLoop();
   }
 
   @Override

--- a/src/main/java/org/littleshoot/proxy/impl/GlobalStateWrapperEvenLoop.java
+++ b/src/main/java/org/littleshoot/proxy/impl/GlobalStateWrapperEvenLoop.java
@@ -58,7 +58,7 @@ public class GlobalStateWrapperEvenLoop implements EventExecutor {
 
   @Override
   public void shutdown() {
-    eventLoop.terminationFuture();
+    eventLoop.shutdown();
   }
 
   @Override

--- a/src/main/java/org/littleshoot/proxy/impl/GlobalStateWrapperEvenLoop.java
+++ b/src/main/java/org/littleshoot/proxy/impl/GlobalStateWrapperEvenLoop.java
@@ -1,0 +1,187 @@
+package org.littleshoot.proxy.impl;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.ProgressivePromise;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.ScheduledFuture;
+
+public class GlobalStateWrapperEvenLoop implements EventExecutor {
+
+  private final ClientToProxyConnection connection;
+
+  private final EventExecutor eventLoop;
+
+  GlobalStateWrapperEvenLoop(ClientToProxyConnection connection) {
+    this.connection = connection;
+    this.eventLoop = connection.channel.eventLoop();
+  }
+
+  GlobalStateWrapperEvenLoop(ClientToProxyConnection connection, EventExecutor eventLoop) {
+    this.connection = connection;
+    this.eventLoop = eventLoop;
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    if (eventLoop.inEventLoop()) {
+      connection.wrapTask(command).run();
+    } else {
+      eventLoop.execute(connection.wrapTask(command));
+    }
+  }
+
+  @Override
+  public boolean isShuttingDown() {
+    return eventLoop.isShuttingDown();
+  }
+
+  @Override
+  public Future<?> shutdownGracefully() {
+    return eventLoop.shutdownGracefully();
+  }
+
+  @Override
+  public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
+    return eventLoop.shutdownGracefully(quietPeriod, timeout, unit);
+  }
+
+  @Override
+  public Future<?> terminationFuture() {
+    return eventLoop.terminationFuture();
+  }
+
+  @Override
+  public void shutdown() {
+    eventLoop.terminationFuture();
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return eventLoop.shutdownNow();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return eventLoop.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return eventLoop.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return eventLoop.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public EventExecutor next() {
+    return this;
+  }
+
+  @Override
+  public Iterator<EventExecutor> iterator() {
+    return eventLoop.iterator();
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    return eventLoop.submit(connection.wrapTask(task));
+  }
+
+  @Override
+  public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+    return eventLoop.invokeAll(tasks);
+  }
+
+  @Override
+  public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+    return eventLoop.invokeAll(tasks, timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+    return eventLoop.invokeAny(tasks);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    return eventLoop.invokeAny(tasks, timeout, unit);
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    return eventLoop.submit(connection.wrapTask(task), result);
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    return eventLoop.submit(task);
+  }
+
+  @Override
+  public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+    return eventLoop.schedule(command, delay, unit);
+  }
+
+  @Override
+  public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+    return eventLoop.schedule(callable, delay, unit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+    return eventLoop.scheduleAtFixedRate(command, initialDelay, period, unit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+    return eventLoop.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+  }
+
+  @Override
+  public EventExecutorGroup parent() {
+    return eventLoop.parent();
+  }
+
+  @Override
+  public boolean inEventLoop() {
+    return false;
+  }
+
+  @Override
+  public boolean inEventLoop(Thread thread) {
+    return eventLoop.inEventLoop(thread);
+  }
+
+  @Override
+  public <V> Promise<V> newPromise() {
+    return eventLoop.newPromise();
+  }
+
+  @Override
+  public <V> ProgressivePromise<V> newProgressivePromise() {
+    return eventLoop.newProgressivePromise();
+  }
+
+  @Override
+  public <V> Future<V> newSucceededFuture(V result) {
+    return eventLoop.newSucceededFuture(result);
+  }
+
+  @Override
+  public <V> Future<V> newFailedFuture(Throwable cause) {
+    return eventLoop.newFailedFuture(cause);
+  }
+}

--- a/src/main/java/org/littleshoot/proxy/impl/HttpInitialHandler.java
+++ b/src/main/java/org/littleshoot/proxy/impl/HttpInitialHandler.java
@@ -1,10 +1,10 @@
 package org.littleshoot.proxy.impl;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpObject;
 
-public class HttpInitialHandler<T extends HttpObject> extends SimpleChannelInboundHandler {
+public class HttpInitialHandler<T extends HttpObject> extends ChannelInboundHandlerAdapter {
 
   private final ProxyConnection<T> proxyConnection;
 
@@ -13,7 +13,7 @@ public class HttpInitialHandler<T extends HttpObject> extends SimpleChannelInbou
   }
 
   @Override
-  protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+  public void channelRead(ChannelHandlerContext ctx, Object msg) {
     final ConnectionState connectionState = proxyConnection.readHTTPInitial(ctx, msg);
     proxyConnection.become(connectionState);
   }

--- a/src/main/java/org/littleshoot/proxy/impl/HttpInitialHandler.java
+++ b/src/main/java/org/littleshoot/proxy/impl/HttpInitialHandler.java
@@ -17,4 +17,9 @@ public class HttpInitialHandler<T extends HttpObject> extends ChannelInboundHand
     final ConnectionState connectionState = proxyConnection.readHTTPInitial(ctx, msg);
     proxyConnection.become(connectionState);
   }
+
+  @Override
+  public final void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    proxyConnection.exceptionCaught(cause);
+  }
 }

--- a/src/main/java/org/littleshoot/proxy/impl/HttpInitialHandler.java
+++ b/src/main/java/org/littleshoot/proxy/impl/HttpInitialHandler.java
@@ -1,0 +1,20 @@
+package org.littleshoot.proxy.impl;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.HttpObject;
+
+public class HttpInitialHandler<T extends HttpObject> extends SimpleChannelInboundHandler {
+
+  private final ProxyConnection<T> proxyConnection;
+
+  HttpInitialHandler(ProxyConnection<T> proxyConnection) {
+    this.proxyConnection = proxyConnection;
+  }
+
+  @Override
+  protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+    final ConnectionState connectionState = proxyConnection.readHTTPInitial(ctx, msg);
+    proxyConnection.become(connectionState);
+  }
+}

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -108,7 +108,7 @@ abstract class ProxyConnection<I extends HttpObject> extends
      * 
      * @param msg
      */
-    protected void read(ChannelHandlerContext ctx, Object msg) {
+    protected void read(Object msg) {
         LOG.debug("Reading: {}", msg);
 
         lastReadTime = System.currentTimeMillis();
@@ -118,7 +118,7 @@ abstract class ProxyConnection<I extends HttpObject> extends
             readRaw((ByteBuf) msg);
         } else {
             // If not tunneling, then we are always dealing with HttpObjects.
-            readHTTP(ctx, (HttpObject) msg);
+            readHTTP((HttpObject) msg);
         }
     }
 
@@ -128,7 +128,7 @@ abstract class ProxyConnection<I extends HttpObject> extends
      * @param httpObject
      */
     @SuppressWarnings("unchecked")
-    private void readHTTP(ChannelHandlerContext ctx, HttpObject httpObject) {
+    private void readHTTP(HttpObject httpObject) {
         switch (getCurrentState()) {
         case AWAITING_INITIAL:
             if (httpObject instanceof HttpMessage) {
@@ -583,7 +583,7 @@ abstract class ProxyConnection<I extends HttpObject> extends
     @Override
     protected final void channelRead0(ChannelHandlerContext ctx, Object msg)
             throws Exception {
-        read(ctx, msg);
+        read(msg);
     }
 
     @Override

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -155,7 +155,11 @@ abstract class ProxyConnection<I extends HttpObject> extends
         case AWAITING_PROXY_AUTHENTICATION:
             if (httpObject instanceof HttpRequest) {
                 // Once we get an HttpRequest, try to process it as usual
-                nextState = readHTTPInitial(ctx, (I) httpObject);
+                if (ctx.name().equals("handlerEnd")) {
+                    nextState = ((ClientToProxyConnection)this).doReadHTTPInitial((HttpRequest) httpObject);
+                } else {
+                    nextState = readHTTPInitial(ctx, (I) httpObject);
+                }
             } else {
                 // Anything that's not an HttpRequest that came in while
                 // we're pending authentication gets dropped on the floor. This

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -180,10 +180,6 @@ abstract class ProxyConnection<I extends HttpObject> extends
         }
     }
 
-    private boolean afterPayloadProcessor(ChannelHandlerContext ctx) {
-        return ctx.name().equals("handlerEnd");
-    }
-
     /**
      * Implement this to handle reading the initial object (e.g.
      * {@link HttpRequest} or {@link HttpResponse}).

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -133,7 +133,7 @@ abstract class ProxyConnection<I extends HttpObject> extends
         switch (getCurrentState()) {
         case AWAITING_INITIAL:
             if (httpObject instanceof HttpMessage) {
-                if (this.ctx.name().equals("handlerEnd")) {
+                if (ctx.name().equals("handlerEnd")) {
                     nextState = ((ClientToProxyConnection)this).doReadHTTPInitial((HttpRequest) httpObject);
                 } else {
                     nextState = readHTTPInitial(ctx, (I) httpObject);

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -129,11 +129,10 @@ abstract class ProxyConnection<I extends HttpObject> extends
      */
     @SuppressWarnings("unchecked")
     private void readHTTP(ChannelHandlerContext ctx, HttpObject httpObject) {
-        ConnectionState nextState = getCurrentState();
         switch (getCurrentState()) {
         case AWAITING_INITIAL:
             if (httpObject instanceof HttpMessage) {
-                nextState = processPayload(ctx, (I) httpObject);
+                ctx.fireChannelRead(httpObject);
             } else {
                 // Similar to the AWAITING_PROXY_AUTHENTICATION case below, we may enter an AWAITING_INITIAL
                 // state if the proxy responded to an earlier request with a 502 or 504 response, or a short-circuit
@@ -145,13 +144,13 @@ abstract class ProxyConnection<I extends HttpObject> extends
         case AWAITING_CHUNK:
             HttpContent chunk = (HttpContent) httpObject;
             readHTTPChunk(chunk);
-            nextState = ProxyUtils.isLastChunk(chunk) ? AWAITING_INITIAL
-                    : AWAITING_CHUNK;
+            become(ProxyUtils.isLastChunk(chunk) ? AWAITING_INITIAL
+                    : AWAITING_CHUNK);
             break;
         case AWAITING_PROXY_AUTHENTICATION:
             if (httpObject instanceof HttpRequest) {
                 // Once we get an HttpRequest, try to process it as usual
-                nextState = processPayload(ctx, (I) httpObject);
+                ctx.fireChannelRead(httpObject);
             } else {
                 // Anything that's not an HttpRequest that came in while
                 // we're pending authentication gets dropped on the floor. This
@@ -179,17 +178,6 @@ abstract class ProxyConnection<I extends HttpObject> extends
             LOG.info("Ignoring message since the connection is closed or about to close");
             break;
         }
-        become(nextState);
-    }
-
-    private ConnectionState processPayload(ChannelHandlerContext ctx, I httpObject) {
-        ConnectionState nextState;
-        if (afterPayloadProcessor(ctx)) {
-            nextState = ((ClientToProxyConnection) this).doReadHTTPInitial((HttpRequest) httpObject);
-        } else {
-            nextState = readHTTPInitial(ctx, httpObject);
-        }
-        return nextState;
     }
 
     private boolean afterPayloadProcessor(ChannelHandlerContext ctx) {
@@ -203,7 +191,7 @@ abstract class ProxyConnection<I extends HttpObject> extends
      * @param httpObject
      * @return
      */
-    protected abstract ConnectionState readHTTPInitial(ChannelHandlerContext ctx, I httpObject);
+    protected abstract ConnectionState readHTTPInitial(ChannelHandlerContext ctx, Object httpObject);
 
     /**
      * Implement this to handle reading a chunk in a chunked transfer.

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -160,6 +160,8 @@ abstract class ProxyConnection<I extends HttpObject> extends
                 // to require authentication.
             }
             break;
+        case CLIENT_TO_PROXY_PROCESSING:
+            ((ClientToProxyConnection)this).doReadHTTPInitial(((ClientToProxyConnection)this).initialHttpRequest, (HttpResponse)httpObject);
         case CONNECTING:
             LOG.warn("Attempted to read from connection that's in the process of connecting.  This shouldn't happen.");
             break;

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -8,6 +8,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
@@ -209,19 +210,19 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
      **************************************************************************/
 
     @Override
-    protected void read(Object msg) {
+    protected void read(ChannelHandlerContext ctx, Object msg) {
         if (isConnecting()) {
             LOG.debug(
                     "In the middle of connecting, forwarding message to connection flow: {}",
                     msg);
             this.connectionFlow.read(msg);
         } else {
-            super.read(msg);
+            super.read(ctx, msg);
         }
     }
 
     @Override
-    protected ConnectionState readHTTPInitial(HttpResponse httpResponse) {
+    protected ConnectionState readHTTPInitial(ChannelHandlerContext ctx, HttpResponse httpResponse) {
         LOG.debug("Received raw response: {}", httpResponse);
 
         if (httpResponse.getDecoderResult().isFailure()) {

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -9,10 +9,10 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.channel.udt.nio.NioUdtProvider;
 import io.netty.handler.codec.http.FullHttpResponse;
@@ -250,10 +250,10 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         return getCurrentState();
     }
 
-    public class RespondToClientHandler extends SimpleChannelInboundHandler {
+    public class RespondToClientHandler extends ChannelInboundHandlerAdapter {
 
         @Override
-        protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
             final HttpResponse httpResponse = (HttpResponse) msg;
             if (ProxyUtils.isChunked(httpResponse)) {
                 respondWith(httpResponse);
@@ -271,6 +271,11 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                         become(AWAITING_INITIAL);
                     }));
             }
+        }
+
+        @Override
+        public final void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            serverConnection.exceptionCaught(cause);
         }
     }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -911,6 +911,10 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     private void initChannelPipeline(ChannelPipeline pipeline,
             Channel channel) {
 
+        if (proxyServer.getGlobalStateHandler() != null) {
+            pipeline.addLast("inboundGlobalStateHandler", new InboundGlobalStateHandler(clientConnection));
+        }
+
         if (trafficHandler != null) {
             pipeline.addLast("global-traffic-shaping", trafficHandler);
         }
@@ -941,6 +945,10 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                 "idle",
                 new IdleStateHandler(0, 0, proxyServer
                         .getIdleConnectionTimeout()));
+
+        if (proxyServer.getGlobalStateHandler() != null) {
+            pipeline.addLast("outboundGlobalStateHandler", new OutboundGlobalStateHandler(clientConnection));
+        }
 
         pipeline.addLast(globalStateWrapperEvenLoop,  "handler", this);
     }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -911,15 +911,11 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     private void initChannelPipeline(ChannelPipeline pipeline,
             Channel channel) {
 
-//        if (proxyServer.getGlobalStateHandler() != null) {
-//            pipeline.addLast("inboundGlobalStateHandler", new InboundGlobalStateHandler(clientConnection));
-//        }
-
         if (trafficHandler != null) {
             pipeline.addLast("global-traffic-shaping", trafficHandler);
         }
 
-        EventExecutorGroup globalStateWrapperEvenLoop = new GlobalStateWrapperEvenLoop(clientConnection, channel.eventLoop());
+        final EventExecutorGroup globalStateWrapperEvenLoop = new GlobalStateWrapperEvenLoop(clientConnection, channel.eventLoop());
 
         pipeline.addLast(globalStateWrapperEvenLoop, "bytesReadMonitor", bytesReadMonitor);
         pipeline.addLast(globalStateWrapperEvenLoop, "bytesWrittenMonitor", bytesWrittenMonitor);
@@ -945,10 +941,6 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                 "idle",
                 new IdleStateHandler(0, 0, proxyServer
                         .getIdleConnectionTimeout()));
-
-//        if (proxyServer.getGlobalStateHandler() != null) {
-//            pipeline.addLast("outboundGlobalStateHandler", new OutboundGlobalStateHandler(clientConnection));
-//        }
 
         pipeline.addLast(globalStateWrapperEvenLoop,  "handler", this);
     }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -267,15 +267,16 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                 proxyServer.getPayloadProcessorExecutor()
                     .execute(clientConnection.wrapTask(() -> {
                       try {
-                        respondWith(httpResponse);
-                        currentFilters.serverToProxyResponseReceived();
-                        become(AWAITING_INITIAL);
+                          respondWith(httpResponse);
+                          currentFilters.serverToProxyResponseReceived();
+                          become(AWAITING_INITIAL);
                       } catch (Exception e) {
-                        if (httpResponse instanceof ReferenceCounted) {
-                          LOG.debug("Retaining reference counted message");
-                          ((ReferenceCounted) httpResponse).release();
-                        }
-                        exceptionCaught(ctx, e);
+                          exceptionCaught(ctx, e);
+                      } finally {
+                          if (httpResponse instanceof ReferenceCounted) {
+                              LOG.debug("Retaining reference counted message");
+                              ((ReferenceCounted) httpResponse).release();
+                          }
                       }
                     }));
             }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -857,6 +857,8 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     private void resetConnectionForRetry() throws UnknownHostException {
         // Remove ourselves as handler on the old context
         this.ctx.pipeline().remove(this);
+        this.ctx.pipeline().remove("httpInitialHandler");
+        this.ctx.pipeline().remove("respondToClientHandler");
         this.ctx.close();
         this.ctx = null;
 

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -223,7 +223,8 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     }
 
     @Override
-    protected ConnectionState readHTTPInitial(ChannelHandlerContext ctx, HttpResponse httpResponse) {
+    protected ConnectionState readHTTPInitial(ChannelHandlerContext ctx, Object httpResponseObj) {
+        HttpResponse httpResponse = (HttpResponse) httpResponseObj;
         LOG.debug("Received raw response: {}", httpResponse);
 
         if (httpResponse.getDecoderResult().isFailure()) {
@@ -951,6 +952,8 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         }
 
         pipeline.addLast(globalStateWrapperEvenLoop,  "handler", this);
+        HttpInitialHandler<HttpResponse> httpInitialHandler = new HttpInitialHandler<>(this);
+        pipeline.addLast(globalStateWrapperEvenLoop,  "httpInitialHandler", httpInitialHandler);
     }
 
     /**

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -264,7 +264,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                     ((ReferenceCounted) httpResponse).retain();
                 }
 
-                proxyServer.getPayloadProcessorExecutor()
+                proxyServer.getMessageProcessingExecutor()
                     .execute(clientConnection.wrapTask(() -> {
                       try {
                           respondWith(httpResponse);

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -658,8 +658,8 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
 
             cb.handler(new ChannelInitializer<Channel>() {
                 protected void initChannel(Channel ch) throws Exception {
-                    initChannelPipeline(ch.pipeline(), initialRequest);
-                };
+                    initChannelPipeline(ch.pipeline(), ch);
+                }
             });
             cb.option(ChannelOption.CONNECT_TIMEOUT_MILLIS,
                     proxyServer.getConnectTimeout());
@@ -911,7 +911,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
      * @param httpRequest
      */
     private void initChannelPipeline(ChannelPipeline pipeline,
-            HttpRequest httpRequest) {
+            Channel channel) {
         if (trafficHandler != null) {
             pipeline.addLast("global-traffic-shaping", trafficHandler);
         }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -54,8 +54,6 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 
 import static org.littleshoot.proxy.impl.ConnectionState.AWAITING_CHUNK;
@@ -256,15 +254,14 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
               ((ReferenceCounted) resp).retain();
             }
 
-            executor.execute(clientConnection.wrapTask(() -> {
+            proxyServer.getPayloadProcessorExecutor()
+                .execute(clientConnection.wrapTask(() -> {
                   currentFilters.serverToProxyResponseReceived();
                   respondWith(resp);
               }));
             return AWAITING_INITIAL;
         }
     }
-
-    Executor executor = Executors.newCachedThreadPool();
 
     @Override
     protected void readHTTPChunk(HttpContent chunk) {

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -256,10 +256,11 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
 
             proxyServer.getPayloadProcessorExecutor()
                 .execute(clientConnection.wrapTask(() -> {
-                  currentFilters.serverToProxyResponseReceived();
                   respondWith(resp);
-              }));
-            return AWAITING_INITIAL;
+                  currentFilters.serverToProxyResponseReceived();
+                  super.become(AWAITING_INITIAL);
+                }));
+            return getCurrentState();
         }
     }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -917,8 +917,8 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
 
         EventLoopGroup globalStateWrapperEvenLoop = clientConnection.new GlobalStateWrapperEvenLoop(channel.eventLoop());
 
-        pipeline.addLast(globalStateWrapperEvenLoop, "bytesReadMonitor", bytesReadMonitor);
-        pipeline.addLast(globalStateWrapperEvenLoop, "bytesWrittenMonitor", bytesWrittenMonitor);
+        pipeline.addLast( "bytesReadMonitor", bytesReadMonitor);
+        pipeline.addLast( "bytesWrittenMonitor", bytesWrittenMonitor);
 
         pipeline.addLast("encoder", new HttpRequestEncoder());
         pipeline.addLast("decoder", new HeadAwareHttpResponseDecoder(
@@ -933,8 +933,8 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             aggregateContentForFiltering(pipeline, numberOfBytesToBuffer);
         }
 
-        pipeline.addLast(globalStateWrapperEvenLoop, "responseReadMonitor", responseReadMonitor);
-        pipeline.addLast(globalStateWrapperEvenLoop, "requestWrittenMonitor", requestWrittenMonitor);
+        pipeline.addLast( "responseReadMonitor", responseReadMonitor);
+        pipeline.addLast( "requestWrittenMonitor", requestWrittenMonitor);
 
         // Set idle timeout
         pipeline.addLast(
@@ -942,7 +942,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                 new IdleStateHandler(0, 0, proxyServer
                         .getIdleConnectionTimeout()));
 
-        pipeline.addLast(globalStateWrapperEvenLoop, "handler", this);
+        pipeline.addLast( "handler", this);
     }
 
     /**

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -254,13 +254,14 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
               ((ReferenceCounted) resp).retain();
             }
 
-            proxyServer.getPayloadProcessorExecutor()
-                .execute(clientConnection.wrapTask(() -> {
+//            proxyServer.getPayloadProcessorExecutor()
+//                .execute(clientConnection.wrapTask(() -> {
                   respondWith(resp);
                   currentFilters.serverToProxyResponseReceived();
-                  super.become(AWAITING_INITIAL);
-                }));
-            return getCurrentState();
+//                  super.become(AWAITING_INITIAL);
+//                }));
+//            return getCurrentState();
+            return AWAITING_INITIAL;
         }
     }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -916,7 +916,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             pipeline.addLast("global-traffic-shaping", trafficHandler);
         }
 
-        EventLoopGroup globalStateWrapperEvenLoop = clientConnection.new GlobalStateWrapperEvenLoop();
+        EventLoopGroup globalStateWrapperEvenLoop = clientConnection.new GlobalStateWrapperEvenLoop(channel.eventLoop());
 
         pipeline.addLast(globalStateWrapperEvenLoop, "bytesReadMonitor", bytesReadMonitor);
         pipeline.addLast(globalStateWrapperEvenLoop, "bytesWrittenMonitor", bytesWrittenMonitor);

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -254,14 +254,13 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
               ((ReferenceCounted) resp).retain();
             }
 
-//            proxyServer.getPayloadProcessorExecutor()
-//                .execute(clientConnection.wrapTask(() -> {
+            proxyServer.getPayloadProcessorExecutor()
+                .execute(clientConnection.wrapTask(() -> {
                   respondWith(resp);
                   currentFilters.serverToProxyResponseReceived();
-//                  super.become(AWAITING_INITIAL);
-//                }));
-//            return getCurrentState();
-            return AWAITING_INITIAL;
+                  super.become(AWAITING_INITIAL);
+                }));
+            return getCurrentState();
         }
     }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -212,14 +212,14 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
      **************************************************************************/
 
     @Override
-    protected void read(ChannelHandlerContext ctx, Object msg) {
+    protected void read(Object msg) {
         if (isConnecting()) {
             LOG.debug(
                     "In the middle of connecting, forwarding message to connection flow: {}",
                     msg);
             this.connectionFlow.read(msg);
         } else {
-            super.read(ctx, msg);
+            super.read(msg);
         }
     }
 
@@ -925,8 +925,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
      * @param pipeline
      * @param httpRequest
      */
-    private void initChannelPipeline(ChannelPipeline pipeline,
-            Channel channel) {
+    private void initChannelPipeline(ChannelPipeline pipeline, Channel channel) {
 
         if (proxyServer.getGlobalStateHandler() != null) {
             pipeline.addLast("inboundGlobalStateHandler", new InboundGlobalStateHandler(clientConnection));

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -250,7 +250,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         return getCurrentState();
     }
 
-    public class RespondToCientHandler extends SimpleChannelInboundHandler {
+    public class RespondToClientHandler extends SimpleChannelInboundHandler {
 
         @Override
         protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
@@ -962,7 +962,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
 
         pipeline.addLast(globalStateWrapperEvenLoop,  "handler", this);
         pipeline.addLast(globalStateWrapperEvenLoop,  "httpInitialHandler", new HttpInitialHandler<>(this));
-        pipeline.addLast(globalStateWrapperEvenLoop,  "respondToClientHandler", new RespondToCientHandler());
+        pipeline.addLast(globalStateWrapperEvenLoop,  "respondToClientHandler", new RespondToClientHandler());
     }
 
     /**

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -916,8 +916,8 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
 
         EventLoopGroup globalStateWrapperEvenLoop = clientConnection.new GlobalStateWrapperEvenLoop(channel.eventLoop());
 
-        pipeline.addLast( "bytesReadMonitor", bytesReadMonitor);
-        pipeline.addLast( "bytesWrittenMonitor", bytesWrittenMonitor);
+        pipeline.addLast(globalStateWrapperEvenLoop, "bytesReadMonitor", bytesReadMonitor);
+        pipeline.addLast(globalStateWrapperEvenLoop, "bytesWrittenMonitor", bytesWrittenMonitor);
 
         pipeline.addLast("encoder", new HttpRequestEncoder());
         pipeline.addLast("decoder", new HeadAwareHttpResponseDecoder(
@@ -932,8 +932,8 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             aggregateContentForFiltering(pipeline, numberOfBytesToBuffer);
         }
 
-        pipeline.addLast( "responseReadMonitor", responseReadMonitor);
-        pipeline.addLast( "requestWrittenMonitor", requestWrittenMonitor);
+        pipeline.addLast(globalStateWrapperEvenLoop, "responseReadMonitor", responseReadMonitor);
+        pipeline.addLast(globalStateWrapperEvenLoop, "requestWrittenMonitor", requestWrittenMonitor);
 
         // Set idle timeout
         pipeline.addLast(

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -250,10 +250,15 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             respondWith(resp);
             return AWAITING_CHUNK;
         } else {
+            if (resp instanceof ReferenceCounted) {
+              LOG.debug("Retaining reference counted message");
+              ((ReferenceCounted) resp).retain();
+            }
+
             executor.execute(() -> {
-                currentFilters.serverToProxyResponseReceived();
-                respondWith(resp);
-            });
+                  currentFilters.serverToProxyResponseReceived();
+                  respondWith(resp);
+              });
             return AWAITING_INITIAL;
         }
     }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -266,9 +266,17 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
 
                 proxyServer.getPayloadProcessorExecutor()
                     .execute(clientConnection.wrapTask(() -> {
+                      try {
                         respondWith(httpResponse);
                         currentFilters.serverToProxyResponseReceived();
                         become(AWAITING_INITIAL);
+                      } catch (Exception e) {
+                        if (httpResponse instanceof ReferenceCounted) {
+                          LOG.debug("Retaining reference counted message");
+                          ((ReferenceCounted) httpResponse).release();
+                        }
+                        exceptionCaught(ctx, e);
+                      }
                     }));
             }
         }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -966,7 +966,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             pipeline.addLast("outboundGlobalStateHandler", new OutboundGlobalStateHandler(clientConnection));
         }
 
-        pipeline.addLast(globalStateWrapperEvenLoop,  "handler", this);
+        pipeline.addLast(globalStateWrapperEvenLoop,  "router", this);
         pipeline.addLast(globalStateWrapperEvenLoop,  "httpInitialHandler", new HttpInitialHandler<>(this));
         pipeline.addLast(globalStateWrapperEvenLoop,  "respondToClientHandler", new RespondToClientHandler());
     }

--- a/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
@@ -300,7 +300,7 @@ public class ServerGroup {
         return getThreadPoolsForProtocol(protocol).getProxyToServerWorkerPool();
     }
 
-    public ExecutorService getPayloadProcessingExecutor() {
+    public ExecutorService getMessageProcessingExecutor() {
         return payloadProcessingExecutor;
     }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
@@ -230,13 +230,13 @@ public class ServerGroup {
             allEventLoopGroups.addAll(threadPools.getAllEventLoops());
         }
 
-//        payloadProcessingExecutor.shutdown();
-//
-//        try {
-//            payloadProcessingExecutor.awaitTermination(10, TimeUnit.SECONDS);
-//        } catch (InterruptedException e) {
-//            log.warn("Failed to shutdown payload processing executor properly", e);
-//        }
+        payloadProcessingExecutor.shutdown();
+
+        try {
+            payloadProcessingExecutor.awaitTermination(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            log.warn("Failed to shutdown payload processing executor properly", e);
+        }
 
         for (EventLoopGroup group : allEventLoopGroups) {
             if (graceful) {

--- a/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
@@ -230,13 +230,13 @@ public class ServerGroup {
             allEventLoopGroups.addAll(threadPools.getAllEventLoops());
         }
 
-        payloadProcessingExecutor.shutdown();
-
-        try {
-            payloadProcessingExecutor.awaitTermination(10, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            log.warn("Failed to shutdown payload processing executor properly", e);
-        }
+//        payloadProcessingExecutor.shutdown();
+//
+//        try {
+//            payloadProcessingExecutor.awaitTermination(10, TimeUnit.SECONDS);
+//        } catch (InterruptedException e) {
+//            log.warn("Failed to shutdown payload processing executor properly", e);
+//        }
 
         for (EventLoopGroup group : allEventLoopGroups) {
             if (graceful) {

--- a/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
@@ -117,7 +117,7 @@ public class ServerGroup {
         this.incomingWorkerThreads = incomingWorkerThreads;
         this.outgoingWorkerThreads = outgoingWorkerThreads;
         if (payloadProcessingExecutor == null) {
-            this.payloadProcessingExecutor = Executors.newFixedThreadPool(incomingWorkerThreads);
+            this.payloadProcessingExecutor = Executors.newCachedThreadPool();
         } else {
             this.payloadProcessingExecutor = payloadProcessingExecutor;
         }

--- a/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
@@ -12,6 +12,8 @@ import java.nio.channels.spi.SelectorProvider;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -72,6 +74,8 @@ public class ServerGroup {
      */
     private final EnumMap<TransportProtocol, ProxyThreadPools> protocolThreadPools = new EnumMap<TransportProtocol, ProxyThreadPools>(TransportProtocol.class);
 
+    private final ExecutorService payloadProcessingExecutor;
+
     /**
      * A mapping of selector providers to transport protocols. Avoids special-casing each transport protocol during
      * transport protocol initialization.
@@ -104,12 +108,19 @@ public class ServerGroup {
      * @param incomingWorkerThreads number of client-to-proxy worker threads per protocol
      * @param outgoingWorkerThreads number of proxy-to-server worker threads per protocol
      */
-    public ServerGroup(String name, int incomingAcceptorThreads, int incomingWorkerThreads, int outgoingWorkerThreads) {
+    public ServerGroup(String name, int incomingAcceptorThreads,
+                       int incomingWorkerThreads, int outgoingWorkerThreads,
+                       ExecutorService payloadProcessingExecutor) {
         this.name = name;
         this.serverGroupId = serverGroupCount.getAndIncrement();
         this.incomingAcceptorThreads = incomingAcceptorThreads;
         this.incomingWorkerThreads = incomingWorkerThreads;
         this.outgoingWorkerThreads = outgoingWorkerThreads;
+        if (payloadProcessingExecutor == null) {
+            this.payloadProcessingExecutor = Executors.newFixedThreadPool(incomingWorkerThreads);
+        } else {
+            this.payloadProcessingExecutor = payloadProcessingExecutor;
+        }
     }
 
     /**
@@ -217,6 +228,14 @@ public class ServerGroup {
 
         for (ProxyThreadPools threadPools : protocolThreadPools.values()) {
             allEventLoopGroups.addAll(threadPools.getAllEventLoops());
+        }
+
+        payloadProcessingExecutor.shutdown();
+
+        try {
+            payloadProcessingExecutor.awaitTermination(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            log.warn("Failed to shutdown payload processing executor properly", e);
         }
 
         for (EventLoopGroup group : allEventLoopGroups) {

--- a/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
@@ -300,6 +300,10 @@ public class ServerGroup {
         return getThreadPoolsForProtocol(protocol).getProxyToServerWorkerPool();
     }
 
+    public ExecutorService getPayloadProcessingExecutor() {
+        return payloadProcessingExecutor;
+    }
+
     /**
      * @return true if this ServerGroup has already been stopped
      */

--- a/src/main/java/org/littleshoot/proxy/impl/UpstreamConnectionHandler.java
+++ b/src/main/java/org/littleshoot/proxy/impl/UpstreamConnectionHandler.java
@@ -1,0 +1,36 @@
+package org.littleshoot.proxy.impl;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+
+public class UpstreamConnectionHandler extends ChannelInboundHandlerAdapter {
+
+  private final ClientToProxyConnection clientToProxyConnection;
+
+  UpstreamConnectionHandler(ClientToProxyConnection clientToProxyConnection) {
+    this.clientToProxyConnection = clientToProxyConnection;
+  }
+
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object request) {
+    final ConnectionState connectionState =
+        clientToProxyConnection.setupUpstreamConnection(((Request)request).getShortCircuitResponse(),
+            ((Request)request).getInitialRequest());
+    clientToProxyConnection.become(connectionState);
+  }
+
+  public static class Request {
+    private final HttpRequest initialRequest;
+    private final HttpResponse shortCircuitResponse;
+
+    public Request(HttpRequest initialRequest, HttpResponse shortCircuitResponse) {
+      this.initialRequest = initialRequest;
+      this.shortCircuitResponse = shortCircuitResponse;
+    }
+
+    HttpRequest getInitialRequest() { return initialRequest; }
+    HttpResponse getShortCircuitResponse() { return shortCircuitResponse; }
+  }
+}

--- a/src/main/java/org/littleshoot/proxy/impl/UpstreamConnectionHandler.java
+++ b/src/main/java/org/littleshoot/proxy/impl/UpstreamConnectionHandler.java
@@ -21,6 +21,11 @@ public class UpstreamConnectionHandler extends SimpleChannelInboundHandler<Objec
     clientToProxyConnection.become(connectionState);
   }
 
+  @Override
+  public final void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    clientToProxyConnection.exceptionCaught(cause);
+  }
+
   public static class Request {
     private final HttpRequest initialRequest;
     private final HttpResponse shortCircuitResponse;

--- a/src/main/java/org/littleshoot/proxy/impl/UpstreamConnectionHandler.java
+++ b/src/main/java/org/littleshoot/proxy/impl/UpstreamConnectionHandler.java
@@ -1,11 +1,11 @@
 package org.littleshoot.proxy.impl;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 
-public class UpstreamConnectionHandler extends ChannelInboundHandlerAdapter {
+public class UpstreamConnectionHandler extends SimpleChannelInboundHandler<Object> {
 
   private final ClientToProxyConnection clientToProxyConnection;
 
@@ -14,7 +14,7 @@ public class UpstreamConnectionHandler extends ChannelInboundHandlerAdapter {
   }
 
   @Override
-  public void channelRead(ChannelHandlerContext ctx, Object request) {
+  protected void channelRead0(ChannelHandlerContext ctx, Object request) {
     final ConnectionState connectionState =
         clientToProxyConnection.setupUpstreamConnection(((Request)request).getShortCircuitResponse(),
             ((Request)request).getInitialRequest());

--- a/src/test/java/org/littleshoot/proxy/ServerGroupTest.java
+++ b/src/test/java/org/littleshoot/proxy/ServerGroupTest.java
@@ -6,6 +6,7 @@ import org.apache.http.HttpResponse;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import org.littleshoot.proxy.impl.ThreadPoolConfiguration;
@@ -188,6 +189,20 @@ public class ServerGroupTest {
         final HttpProxyServer proxyServer = getProxy(2, false,
             false, false, false, true,
             false, false, false, false);
+
+        final Futures futures = runTwoRequests(proxyServer);
+
+        futures.getFirstFuture().get();
+        futures.getSecondFuture().get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    @Ignore // for some reason the test hangs even with original logic
+    public void testExceptionFirstResponse() throws ExecutionException, InterruptedException {
+
+        final HttpProxyServer proxyServer = getProxy(2, false,
+            false, false, false, false,
+            false, true, false, false);
 
         final Futures futures = runTwoRequests(proxyServer);
 

--- a/src/test/java/org/littleshoot/proxy/ServerGroupTest.java
+++ b/src/test/java/org/littleshoot/proxy/ServerGroupTest.java
@@ -27,81 +27,128 @@ import static org.junit.Assert.fail;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
+
+// set up two server responses that will execute more or less simultaneously. the first request has a small
+// delay, to reduce the chance that the first request will finish entirely before the second  request is finished
+// (and thus be somewhat more likely to be serviced by the same thread, even if the ThreadPoolConfiguration is
+// not behaving properly).
+
+
+// save the names of the threads that execute the filter methods. filter methods are executed by the worker thread
+// handling the request/response, so if there is only one worker thread, the filter methods should be executed
+// by the same thread.
+
 public class ServerGroupTest {
     private ClientAndServer mockServer;
     private int mockServerPort;
 
-    private HttpProxyServer proxyServer;
+    final String firstRequestPath = "/testSingleThreadFirstRequest";
+    final String secondRequestPath = "/testSingleThreadSecondRequest";
+    final String messageProcessingThreadName = UUID.randomUUID().toString();
+
+    final AtomicReference<String> firstClientThreadName = new AtomicReference<String>();
+    final AtomicReference<String> secondClientThreadName = new AtomicReference<String>();
+
+    final AtomicReference<String> firstProxyThreadName = new AtomicReference<String>();
+    final AtomicReference<String> secondProxyThreadName = new AtomicReference<String>();
 
     @Before
     public void setUp() {
         mockServer = new ClientAndServer(0);
         mockServerPort = mockServer.getPort();
+
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath(firstRequestPath),
+            Times.exactly(1))
+            .respond(response()
+                .withStatusCode(200)
+                .withBody("first")
+                .withDelay(TimeUnit.MILLISECONDS, 500)
+            );
+
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath(secondRequestPath),
+            Times.exactly(1))
+            .respond(response()
+                .withStatusCode(200)
+                .withBody("second")
+            );
     }
 
     @After
     public void tearDown() {
-        try {
-            if (mockServer != null) {
-                mockServer.stop();
-            }
-        } finally {
-            if (proxyServer != null) {
-                proxyServer.abort();
-            }
+        if (mockServer != null) {
+            mockServer.stop();
         }
     }
 
     @Test
     public void testSingleWorkerThreadPoolConfiguration() throws ExecutionException, InterruptedException {
-        final String firstRequestPath = "/testSingleThreadFirstRequest";
-        final String secondRequestPath = "/testSingleThreadSecondRequest";
-        final String messageProcessingThreadName = UUID.randomUUID().toString();
 
-        // set up two server responses that will execute more or less simultaneously. the first request has a small
-        // delay, to reduce the chance that the first request will finish entirely before the second  request is finished
-        // (and thus be somewhat more likely to be serviced by the same thread, even if the ThreadPoolConfiguration is
-        // not behaving properly).
-        mockServer.when(request()
-                        .withMethod("GET")
-                        .withPath(firstRequestPath),
-                Times.exactly(1))
-                .respond(response()
-                                .withStatusCode(200)
-                                .withBody("first")
-                                .withDelay(TimeUnit.MILLISECONDS, 500)
-                );
+        final HttpProxyServer proxyServer = getProxy(2, true,
+            false, false, false, false,
+            false, false, false, false);
 
-        mockServer.when(request()
-                        .withMethod("GET")
-                        .withPath(secondRequestPath),
-                Times.exactly(1))
-                .respond(response()
-                                .withStatusCode(200)
-                                .withBody("second")
-                );
+        final Futures futures = runTwoRequests(proxyServer);
 
-        // save the names of the threads that execute the filter methods. filter methods are executed by the worker thread
-        // handling the request/response, so if there is only one worker thread, the filter methods should be executed
-        // by the same thread.
-        final AtomicReference<String> firstClientThreadName = new AtomicReference<String>();
-        final AtomicReference<String> secondClientThreadName = new AtomicReference<String>();
+        try {
+            futures.getSecondFuture().get(2, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            fail("Second request took longer than expected");
+        }
 
-        final AtomicReference<String> firstProxyThreadName = new AtomicReference<String>();
-        final AtomicReference<String> secondProxyThreadName = new AtomicReference<String>();
+        boolean firstStillExecuting = false;
+        try {
+            futures.getFirstFuture().get(2, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            firstStillExecuting = true;
+        }
 
-        proxyServer = DefaultHttpProxyServer.bootstrap()
+        Assert.assertTrue("First request must be still executing", firstStillExecuting);
+
+        try {
+            futures.getFirstFuture().get(3, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            fail("First request took longer than expected");
+        }
+
+        assertEquals("Expected clientToProxy filter methods to be executed on the same thread for both requests", firstClientThreadName.get(), secondClientThreadName.get());
+        assertEquals("Expected serverToProxy filter methods to be executed on the same thread for both requests", firstProxyThreadName.get(), secondProxyThreadName.get());
+
+        assertEquals(firstClientThreadName.get(), messageProcessingThreadName);
+        assertEquals(firstProxyThreadName.get(), messageProcessingThreadName);
+    }
+
+    private HttpProxyServer getProxy(int processingThreads,
+                                     boolean blockFirstRequest,
+                                     boolean blockSecondRequest,
+                                     boolean blockFirstResponse,
+                                     boolean blockSecondResponse,
+                                     boolean throwFirstRequestException,
+                                     boolean throwSecondRequestException,
+                                     boolean throwFirstResponseException,
+                                     boolean throwSecondResponseException,
+                                     boolean withChunks) {
+        return DefaultHttpProxyServer.bootstrap()
                 .withPort(0)
                 .withFiltersSource(new HttpFiltersSourceAdapter() {
 
                     // required so chinks for used
                     @Override
                     public int getMaximumRequestBufferSizeInBytes() {
+                        if (withChunks) {
+                            return 0;
+                        }
                         return 8388608 * 2;
                     }
 
                     @Override
                     public int getMaximumResponseBufferSizeInBytes() {
+                        if (withChunks) {
+                            return 0;
+                        }
                         return 8388608 * 2;
                     }
 
@@ -114,14 +161,24 @@ public class ServerGroupTest {
                                 if (originalRequest.getUri().endsWith(firstRequestPath)) {
                                     firstClientThreadName.set(Thread.currentThread().getName());
 
-                                    try {
-                                        Thread.sleep(4000);
-                                    } catch (InterruptedException e) {
-                                        e.printStackTrace();
+                                    if (throwFirstRequestException) {
+                                        throw new RuntimeException("first-request");
+                                    }
+
+                                    if (blockFirstRequest) {
+                                        block();
                                     }
 
                                 } else if (originalRequest.getUri().endsWith(secondRequestPath)) {
                                     secondClientThreadName.set(Thread.currentThread().getName());
+
+                                    if (throwSecondRequestException) {
+                                        throw new RuntimeException("second-request");
+                                    }
+
+                                    if (blockSecondRequest) {
+                                        block();
+                                    }
                                 }
 
                                 return super.clientToProxyRequest(httpObject);
@@ -131,8 +188,25 @@ public class ServerGroupTest {
                             public HttpObject serverToProxyResponse(HttpObject httpObject) {
                                 if (originalRequest.getUri().endsWith(firstRequestPath)) {
                                     firstProxyThreadName.set(Thread.currentThread().getName());
+
+                                    if (throwFirstResponseException) {
+                                        throw new RuntimeException("first-response");
+                                    }
+
+                                    if (blockFirstResponse) {
+                                        block();
+                                    }
+
                                 } else if (originalRequest.getUri().endsWith(secondRequestPath)) {
                                     secondProxyThreadName.set(Thread.currentThread().getName());
+
+                                    if (throwSecondResponseException) {
+                                        throw new RuntimeException("second-response");
+                                    }
+
+                                    if (blockSecondResponse) {
+                                        block();
+                                    }
                                 }
                                 return httpObject;
                             }
@@ -143,29 +217,33 @@ public class ServerGroupTest {
                         .withAcceptorThreads(1)
                         .withClientToProxyWorkerThreads(1)
                         .withProxyToServerWorkerThreads(1))
-                .withMessageProcessingExecutor(Executors.newFixedThreadPool(2, r -> {
+                .withMessageProcessingExecutor(Executors.newFixedThreadPool(processingThreads, r -> {
                     final Thread thread = new Thread(r);
                     thread.setName(messageProcessingThreadName);
                     return thread;
                 }))
                 .start();
+    }
 
+    private void block() {
+        try {
+            Thread.sleep(4000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private Futures runTwoRequests(HttpProxyServer proxyServer) throws InterruptedException {
         // execute both requests in parallel, to increase the chance of blocking due to the single-threaded ThreadPoolConfiguration
 
-        Runnable firstRequest = new Runnable() {
-            @Override
-            public void run() {
-                HttpResponse response = HttpClientUtil.performHttpGet("http://localhost:" + mockServerPort + firstRequestPath, proxyServer);
-                assertEquals(200, response.getStatusLine().getStatusCode());
-            }
+        final Runnable firstRequest = () -> {
+            HttpResponse response = HttpClientUtil.performHttpGet("http://localhost:" + mockServerPort + firstRequestPath, proxyServer);
+            assertEquals(200, response.getStatusLine().getStatusCode());
         };
 
-        Runnable secondRequest = new Runnable () {
-            @Override
-            public void run() {
-                HttpResponse response = HttpClientUtil.performHttpGet("http://localhost:" + mockServerPort + secondRequestPath, proxyServer);
-                assertEquals(200, response.getStatusLine().getStatusCode());
-            }
+        final Runnable secondRequest = () -> {
+            HttpResponse response = HttpClientUtil.performHttpGet("http://localhost:" + mockServerPort + secondRequestPath, proxyServer);
+            assertEquals(200, response.getStatusLine().getStatusCode());
         };
 
         ExecutorService executor = Executors.newFixedThreadPool(2);
@@ -173,33 +251,26 @@ public class ServerGroupTest {
         Thread.sleep(500);
         Future<?> secondFuture = executor.submit(secondRequest);
 
-
-        try {
-            secondFuture.get(2, TimeUnit.SECONDS);
-        } catch (TimeoutException e) {
-            fail("Second request took longer than expected");
-        }
-
-        boolean firstStillExecuting = false;
-        try {
-            firstFuture.get(2, TimeUnit.SECONDS);
-        } catch (TimeoutException e) {
-            firstStillExecuting = true;
-        }
-
-        Assert.assertTrue("First request must be still executing", firstStillExecuting);
-
-        try {
-            firstFuture.get(3, TimeUnit.SECONDS);
-        } catch (TimeoutException e) {
-            fail("First request took longer than expected");
-        }
-
-        assertEquals("Expected clientToProxy filter methods to be executed on the same thread for both requests", firstClientThreadName.get(), secondClientThreadName.get());
-        assertEquals("Expected serverToProxy filter methods to be executed on the same thread for both requests", firstProxyThreadName.get(), secondProxyThreadName.get());
-
-        assertEquals(firstClientThreadName.get(), messageProcessingThreadName);
-        assertEquals(firstProxyThreadName.get(), messageProcessingThreadName);
+        return new Futures(firstFuture, secondFuture);
     }
+
+    private static class Futures {
+        Future<?> getFirstFuture() {
+            return firstFuture;
+        }
+
+        Future<?> getSecondFuture() {
+            return secondFuture;
+        }
+
+        final Future<?> firstFuture;
+        final Future<?> secondFuture;
+
+        private Futures(Future<?> firstFuture, Future<?> secondFuture) {
+            this.firstFuture = firstFuture;
+            this.secondFuture = secondFuture;
+        }
+    }
+
 
 }


### PR DESCRIPTION
**Fixes https://app.clubhouse.io/vgs/story/12753/refactor-littleproxy**

Problem: 
1. Everything is executed in worker threads
2. A channel is registered with a worker thread not based on worker availability but using round robin algorithm. The thread is selected here https://github.com/netty/netty/blob/00afb19d7a37de21b35ce4f6cb3fa7f74809f2ab/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java#L137. Chooser is https://github.com/netty/netty/blob/00afb19d7a37de21b35ce4f6cb3fa7f74809f2ab/common/src/main/java/io/netty/util/concurrent/DefaultEventExecutorChooserFactory.java
3. If one channel blocks a worker, other channel can subscribe to the same thread and get blocked as well. Does not matter how many worker threads there are.

Solutions:
1. Hack main even loop
2. Provide handlers with custom event loops
3. Extract processing logic and run it in a separate executor service

Chosen solution: 3

Comments:
In Netty all the tasks related to the same channel must be executed strictly in order. Event loop executes tasks which are any possible work done by Netty. For example executing `fireChannelRead` from a separate thread will create a task and put it into main event loop task queue.

Also event loop is shared between channels and all the tasks (for different channels) are in one queue and executed in one loop iteration.

Hacking event loop by adding some sort of cached executor makes LP unstable in some cases. A task may be executed in incorrect order leading to issues which are hard to debug. 

And the main issue with that is that it goes opposite to Netty principles. 