### PR TITLE
Account for chunked Brotli stream

### DIFF
--- a/src/main/java/io/netty/handler/codec/compression/BrotliDecoder.java
+++ b/src/main/java/io/netty/handler/codec/compression/BrotliDecoder.java
@@ -64,7 +64,7 @@ public class BrotliDecoder extends ByteToMessageDecoder {
       // stream is corrupted or not ready (retriable)
       // exit condition will be reached when Netty has nothing more to add to the buffer
       // and this function is not able to decode any messages to "out"
-      log.warn("Brotli stream was not ready for consumption");
+      log.warn("Brotli stream was not ready for consumption", ioe);
       success = false;
     } catch (Exception e) {
       success = false;

--- a/src/main/java/io/netty/handler/codec/compression/BrotliDecoder.java
+++ b/src/main/java/io/netty/handler/codec/compression/BrotliDecoder.java
@@ -56,6 +56,7 @@ public class BrotliDecoder extends ByteToMessageDecoder {
       decompress(bbin, bbout);
       if (!result.isReadable()) {
         success = false;
+        log.warn("Decoded result is not readable");
         return;
       }
       out.add(result);
@@ -63,6 +64,7 @@ public class BrotliDecoder extends ByteToMessageDecoder {
       // stream is corrupted or not ready (retriable)
       // exit condition will be reached when Netty has nothing more to add to the buffer
       // and this function is not able to decode any messages to "out"
+      log.warn("Brotli stream was not ready for consumption");
       success = false;
     } catch (Exception e) {
       success = false;

--- a/src/test/java/org/littleshoot/proxy/BrotliEncoderDecoderTest.java
+++ b/src/test/java/org/littleshoot/proxy/BrotliEncoderDecoderTest.java
@@ -1,15 +1,27 @@
 package org.littleshoot.proxy;
 
+import static java.lang.Float.parseFloat;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
 import com.google.common.io.ByteSource;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Resources;
-
 import com.nixxcode.jvmbrotli.common.BrotliLoader;
-import com.nixxcode.jvmbrotli.dec.BrotliInputStream;
 import com.nixxcode.jvmbrotli.enc.Encoder;
-
 import io.netty.handler.codec.compression.BrotliDecoder;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -42,23 +54,6 @@ import org.junit.Test;
 import org.littleshoot.proxy.extras.SelfSignedSslEngineSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
-
-import javax.net.ssl.SSLContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import static java.lang.Float.parseFloat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 
 public class BrotliEncoderDecoderTest extends AbstractProxyTest {
 
@@ -387,14 +382,14 @@ public class BrotliEncoderDecoderTest extends AbstractProxyTest {
     if (compressedArray == null) {
       return null;
     }
-
-    ByteArrayOutputStream out;
-    try (BrotliInputStream is = new BrotliInputStream(new ByteArrayInputStream(compressedArray))) {
-      out = new ByteArrayOutputStream();
-      if (!BrotliDecoder.decompress(out, is)) {
-        return null;
-      }
+    try (
+        InputStream in = new ByteArrayInputStream(compressedArray);
+        ByteArrayOutputStream out = new ByteArrayOutputStream()
+    ) {
+      BrotliDecoder.decompress(in, out);
       return out.toByteArray();
+    } catch (Exception e) {
+      return null;
     }
   }
 }


### PR DESCRIPTION
## Description
This PR aims to fix the logic assumed by the original code.

The TCP stream may arrive in chunks and is propagated using multiple `decode()` calls by Netty. The jvmbrotli implementation (as well as native Brotli via Apache Commons Compress) cannot work with chunked input. This code is trying to decompress and resets the inbound stream if there was a failure.

The code was also refactored a bit, hopefully it doesn't make the review much harder. :)