### PR TITLE
Empty trace id on Upstream closes connection fix

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -804,6 +804,16 @@ abstract class ProxyConnection<I extends HttpObject> extends
                 proxyServer.getGlobalStateHandler().clear();
             }
         }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+            try {
+                proxyServer.getGlobalStateHandler().restoreFromChannel(clientToProxyConnection.channel);
+                super.channelInactive(ctx);
+            } finally {
+                proxyServer.getGlobalStateHandler().clear();
+            }
+        }
     }
 
     @Sharable


### PR DESCRIPTION
Fixes https://verygoodsecurity.atlassian.net/browse/VAULT-579

Restores context (trace_id, span_id) on an Upstream closes connection. 