### PR TITLE
Allow Blocking HTTP Pipelining

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -434,4 +434,17 @@ public interface HttpProxyServerBootstrap {
      * @param rateLimiter
      */
     HttpProxyServerBootstrap withRateLimiter(RateLimiter rateLimiter);
+
+    /**
+     * <p>
+     * Specify whether to block http pipelining
+     * </p>
+     *
+     * <p>
+     * Default = false
+     * </p>
+     *
+     * @param blockHttpPipelining
+     */
+    HttpProxyServerBootstrap withHttpPipeliningBlocked(boolean blockHttpPipelining);
 }

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -794,14 +794,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     private void initChannelPipeline(ChannelPipeline pipeline) {
         LOG.debug("Configuring ChannelPipeline");
 
-        if (proxyServer.getRequestTracer() != null) {
-            pipeline.addLast("requestTracerHandler", new RequestTracerHandler(this));
-        }
-
-        if (proxyServer.getGlobalStateHandler() != null) {
-            pipeline.addLast("inboundGlobalStateHandler", new InboundGlobalStateHandler(this));
-        }
-
         pipeline.addLast("bytesReadMonitor", bytesReadMonitor);
         pipeline.addLast("bytesWrittenMonitor", bytesWrittenMonitor);
 
@@ -822,6 +814,16 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                 .getMaximumRequestBufferSizeInBytes();
         if (numberOfBytesToBuffer > 0) {
             aggregateContentForFiltering(pipeline, numberOfBytesToBuffer);
+        }
+
+        pipeline.addLast("httpPipeliningBlocker", new HttpPipeliningBlocker());
+
+        if (proxyServer.getRequestTracer() != null) {
+            pipeline.addLast("requestTracerHandler", new RequestTracerHandler(this));
+        }
+
+        if (proxyServer.getGlobalStateHandler() != null) {
+            pipeline.addLast("inboundGlobalStateHandler", new InboundGlobalStateHandler(this));
         }
 
         pipeline.addLast("requestReadMonitor", requestReadMonitor);

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -816,7 +816,9 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             aggregateContentForFiltering(pipeline, numberOfBytesToBuffer);
         }
 
-        pipeline.addLast("httpPipeliningBlocker", new HttpPipeliningBlocker());
+        if (proxyServer.isHttpPipeliningBlocked()) {
+            pipeline.addLast("httpPipeliningBlocker", new HttpPipeliningBlocker());
+        }
 
         if (proxyServer.getRequestTracer() != null) {
             pipeline.addLast("requestTracerHandler", new RequestTracerHandler(this));

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -133,6 +133,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
     private final int maxChunkSize;
     private final boolean allowRequestsToOriginServer;
     private final RateLimiter rateLimiter;
+    private final boolean httpPipeliningBlocked;
 
     /**
      * The alias or pseudonym for this proxy, used when adding the Via header.
@@ -274,7 +275,8 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             int maxHeaderSize,
             int maxChunkSize,
             boolean allowRequestsToOriginServer,
-            RateLimiter rateLimiter) {
+            RateLimiter rateLimiter,
+            boolean httpPipeliningBlocked) {
         this.serverGroup = serverGroup;
         this.transportProtocol = transportProtocol;
         this.requestedAddress = requestedAddress;
@@ -319,6 +321,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         this.maxChunkSize = maxChunkSize;
         this.allowRequestsToOriginServer = allowRequestsToOriginServer;
         this.rateLimiter = rateLimiter;
+        this.httpPipeliningBlocked = httpPipeliningBlocked;
     }
 
     /**
@@ -412,6 +415,10 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         return rateLimiter;
     }
 
+    public boolean isHttpPipeliningBlocked() {
+        return httpPipeliningBlocked;
+    }
+
 	public boolean isAllowRequestsToOriginServer() {
         return allowRequestsToOriginServer;
     }
@@ -446,7 +453,8 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
                     maxHeaderSize,
                     maxChunkSize,
                     allowRequestsToOriginServer,
-                    rateLimiter);
+                    rateLimiter,
+                    httpPipeliningBlocked);
     }
 
     @Override
@@ -692,6 +700,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         private boolean allowRequestToOriginServer = false;
         private RateLimiter rateLimiter = new NoOpRateLimiter();
         private ProxyThreadPoolsObserver threadPoolObserver = new NoOpProxyThreadPoolsObserver();
+        private boolean httpPipeliningBlocked = false;
 
         private DefaultHttpProxyServerBootstrap() {
         }
@@ -722,7 +731,8 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
                 int maxHeaderSize,
                 int maxChunkSize,
                 boolean allowRequestToOriginServer,
-                RateLimiter rateLimiter) {
+                RateLimiter rateLimiter,
+                boolean httpPipeliningBlocked) {
             this.serverGroup = serverGroup;
             this.transportProtocol = transportProtocol;
             this.requestedAddress = requestedAddress;
@@ -754,6 +764,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         	this.maxChunkSize = maxChunkSize;
         	this.allowRequestToOriginServer = allowRequestToOriginServer;
           this.rateLimiter = rateLimiter;
+          this.httpPipeliningBlocked = httpPipeliningBlocked;
         }
 
         private DefaultHttpProxyServerBootstrap(Properties props) {
@@ -1012,6 +1023,12 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             return this;
         }
 
+        @Override
+        public HttpProxyServerBootstrap withHttpPipeliningBlocked(boolean httpPipeliningBlocked) {
+            this.httpPipeliningBlocked = httpPipeliningBlocked;
+            return this;
+        }
+
         private DefaultHttpProxyServer build() {
             final ServerGroup serverGroup;
 
@@ -1036,7 +1053,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
                     idleConnectionTimeout, activityTrackers, connectTimeout,
                     serverResolver, readThrottleBytesPerSecond, writeThrottleBytesPerSecond,
                     localAddress, proxyAlias, maxInitialLineLength, maxHeaderSize, maxChunkSize,
-                    allowRequestToOriginServer, rateLimiter);
+                    allowRequestToOriginServer, rateLimiter, httpPipeliningBlocked);
         }
 
         private InetSocketAddress determineListenAddress() {

--- a/src/main/java/org/littleshoot/proxy/impl/HttpPipeliningBlocker.java
+++ b/src/main/java/org/littleshoot/proxy/impl/HttpPipeliningBlocker.java
@@ -1,0 +1,59 @@
+package org.littleshoot.proxy.impl;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import java.util.LinkedList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class HttpPipeliningBlocker extends ChannelDuplexHandler {
+  private static final Logger logger = LoggerFactory.getLogger(HttpPipeliningBlocker.class);
+
+  private final LinkedList<FullHttpRequest> requestQueue = new LinkedList<>();
+  private boolean requestIsBeingProcessed = false;
+
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object msg) {
+    if (!(msg instanceof FullHttpRequest)) {
+      String messageType = msg != null ? msg.getClass().getName() : "null";
+      logger.warn("Unexpected message type: {}. Ignoring the message.", messageType);
+      return;
+    }
+
+    FullHttpRequest request = (FullHttpRequest) msg;
+    if (!requestIsBeingProcessed && requestQueue.isEmpty()) {
+      processRequest(ctx, request);
+    } else {
+      requestQueue.addLast(request);
+      logger.debug("One of the previous requests is already being processed. Added current request to the queue. "
+          + "Queue size: {}", requestQueue.size());
+    }
+  }
+
+  private void processRequest(ChannelHandlerContext ctx, FullHttpRequest request) {
+    requestIsBeingProcessed = true;
+    ctx.fireChannelRead(request);
+  }
+
+  @Override
+  public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+    ctx.write(msg, promise);
+    if (!(msg instanceof FullHttpResponse)) {
+      return;
+    }
+    requestIsBeingProcessed = false;
+    if (!requestQueue.isEmpty()) {
+      ctx.executor().execute(() -> {
+        if (!requestIsBeingProcessed && !requestQueue.isEmpty()) {
+          FullHttpRequest request = requestQueue.pollFirst();
+          logger.debug("Polled next request from the queue for processing. Queue size: {}", requestQueue.size());
+          processRequest(ctx, request);
+        }
+      });
+    }
+  }
+}

--- a/src/test/java/org/littleshoot/proxy/impl/HttpPipeliningBlockerTest.java
+++ b/src/test/java/org/littleshoot/proxy/impl/HttpPipeliningBlockerTest.java
@@ -1,0 +1,91 @@
+package org.littleshoot.proxy.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.util.concurrent.EventExecutor;
+import org.junit.Test;
+
+public class HttpPipeliningBlockerTest {
+  private final HttpPipeliningBlocker httpPipeliningBlocker = new HttpPipeliningBlocker();
+
+  private final ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+  private final EventExecutor eventExecutor = mock(EventExecutor.class);
+  private final ChannelPromise promise = mock(ChannelPromise.class);
+  private final FullHttpRequest request1 = mock(FullHttpRequest.class, "request1");
+  private final FullHttpRequest request2 = mock(FullHttpRequest.class, "request2");
+  private final FullHttpResponse response1 = mock(FullHttpResponse.class, "response1");
+
+  @Test
+  public void doesntStartProcessingOfTheNextRequestIfThePreviousOneHasntBeenProcessedYet() {
+    httpPipeliningBlocker.channelRead(ctx, request1);
+    httpPipeliningBlocker.channelRead(ctx, request2);
+
+    verify(ctx, times(1)).fireChannelRead(request1);
+    verify(ctx, times(0)).fireChannelRead(request2);
+    verifyNoMoreInteractions(ctx);
+  }
+
+  @Test
+  public void ignoresMessageIfItIsNotFullHttpRequest() {
+    httpPipeliningBlocker.channelRead(ctx, "a string");
+    verify(ctx, times(0)).fireChannelRead(any());
+  }
+
+  @Test
+  public void ignoresMessageIfItIsNull() {
+    httpPipeliningBlocker.channelRead(ctx, null);
+    verify(ctx, times(0)).fireChannelRead(any());
+  }
+
+  @Test
+  public void triggersProcessingOfTheNextRequestInTheQueueIfThereIsAny() {
+    when(ctx.executor()).thenReturn(eventExecutor);
+    doAnswer(invocation -> {
+      Runnable task = invocation.getArgument(0);
+      task.run();
+      return null;
+    }).when(eventExecutor).execute(any(Runnable.class));
+
+    httpPipeliningBlocker.channelRead(ctx, request1);
+    httpPipeliningBlocker.channelRead(ctx, request2);
+    httpPipeliningBlocker.write(ctx, response1, promise);
+
+    verify(ctx, times(1)).executor();
+    verify(ctx, times(1)).fireChannelRead(request2);
+  }
+
+  @Test
+  public void doesntUseEventExecutorIfQueueIsEmpty() {
+    httpPipeliningBlocker.channelRead(ctx, request1);
+    httpPipeliningBlocker.write(ctx, response1, promise);
+
+    verify(ctx, times(0)).executor();
+  }
+
+  @Test
+  public void doesntTriggerProcessingOfTheNextRequestInTheQueueIfResponseMessageIsNotInstanceOfFullHttpResponse() {
+    httpPipeliningBlocker.channelRead(ctx, request1);
+    httpPipeliningBlocker.write(ctx, "a string", promise);
+
+    verify(ctx, times(0)).executor();
+  }
+
+  @Test
+  public void doesntAllowProcessingOfTheNextReceivedRequestIfResponseMessageIsNotInstanceOfFullHttpResponse() {
+    httpPipeliningBlocker.channelRead(ctx, request1);
+    httpPipeliningBlocker.write(ctx, "a string", promise);
+
+    httpPipeliningBlocker.channelRead(ctx, request2);
+    verify(ctx, times(0)).fireChannelRead(request2);
+  }
+}


### PR DESCRIPTION
Allow to block HTTP pipelining: queue a new http request if the previous one in the same http connection hasn't been processed and the response hasn't been sent back to the client yet.
- https://en.wikipedia.org/wiki/HTTP_pipelining