### PR TITLE
Update dnsjava library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <barchart-udt-bundle.version>2.3.0</barchart-udt-bundle.version>
         <commons-cli.version>1.5.0</commons-cli.version>
-        <dnsjava.version>2.1.8</dnsjava.version>
+        <dnsjava.version>3.5.2</dnsjava.version>
         <dnssec4j.version>0.1.6</dnssec4j.version>
         <jvmbrotli.version>0.2.0</jvmbrotli.version>
 


### PR DESCRIPTION
Update `dnsjava` 2.1.8(Released in 2017) -> 3.5.2(Released in 2022)